### PR TITLE
feat: Temporary chat

### DIFF
--- a/src/app/(authenticated)/chat/temporary/loading.tsx
+++ b/src/app/(authenticated)/chat/temporary/loading.tsx
@@ -1,0 +1,5 @@
+import { PageLoader } from "@/features/ui/page-loader";
+
+export default function Loading() {
+  return <PageLoader />;
+}

--- a/src/app/(authenticated)/chat/temporary/page.tsx
+++ b/src/app/(authenticated)/chat/temporary/page.tsx
@@ -1,0 +1,70 @@
+import { userHashedId } from "@/features/auth-page/helpers";
+import { ChatPage } from "@/features/chat-page/chat-page";
+import { FindAllChatDocuments } from "@/features/chat-page/chat-services/chat-document-service";
+import { FindAllChatMessagesForCurrentUser } from "@/features/chat-page/chat-services/chat-message-service";
+import {
+  CreateChatThread,
+  FindChatThreadForCurrentUser,
+  ResetChatThread,
+} from "@/features/chat-page/chat-services/chat-thread-service";
+import { FindAllExtensionForCurrentUserAndIds } from "@/features/extensions-page/extension-services/extension-service";
+import { AI_NAME, TEMPORARY_CHAT_NAME, TEMPORARY_CHAT_ROUTE } from "@/features/theme/theme-config";
+import { DisplayError } from "@/features/ui/error/display-error";
+import { redirect } from "next/navigation";
+
+export const metadata = {
+  title: AI_NAME,
+  description: AI_NAME,
+};
+
+interface HomeParams {
+  params: Promise<{
+    id: string;
+  }>;
+}
+
+export default async function Home(props: HomeParams) {
+  const userIdAsChatThreadId = await userHashedId();
+  const [chatResponse, chatThreadResponse, docsResponse] = await Promise.all([
+    FindAllChatMessagesForCurrentUser(userIdAsChatThreadId),
+    FindChatThreadForCurrentUser(userIdAsChatThreadId),
+    FindAllChatDocuments(userIdAsChatThreadId),
+  ]);
+
+  if (chatThreadResponse.status === "OK" && chatResponse.status === "OK" && chatResponse.response.length ) {
+    await ResetChatThread(userIdAsChatThreadId);
+    redirect(TEMPORARY_CHAT_ROUTE);
+  } else if (chatThreadResponse.status === "NOT_FOUND") {
+    await CreateChatThread({ id: userIdAsChatThreadId, name: TEMPORARY_CHAT_NAME, temporary: true });
+    redirect(TEMPORARY_CHAT_ROUTE);
+  }
+
+  if (docsResponse.status !== "OK") {
+    return <DisplayError errors={docsResponse.errors} />;
+  }
+
+  if (chatResponse.status !== "OK") {
+    return <DisplayError errors={chatResponse.errors} />;
+  }
+
+  if (chatThreadResponse.status !== "OK") {
+    return <DisplayError errors={chatThreadResponse.errors} />;
+  }
+
+  const extensionResponse = await FindAllExtensionForCurrentUserAndIds(
+    chatThreadResponse.response.extension
+  );
+
+  if (extensionResponse.status !== "OK") {
+    return <DisplayError errors={extensionResponse.errors} />;
+  }
+
+  return (
+    <ChatPage
+      messages={chatResponse.response}
+      chatThread={chatThreadResponse.response}
+      chatDocuments={docsResponse.response}
+      extensions={extensionResponse.response}
+    />
+  );
+}

--- a/src/features/chat-page/chat-header/chat-header.tsx
+++ b/src/features/chat-page/chat-header/chat-header.tsx
@@ -9,6 +9,7 @@ import { ExtensionDetail } from "./extension-detail";
 import { ModelSelector } from "./model-selector";
 import { PersonaDetail } from "./persona-detail";
 import { MobileHeader } from "@/features/ui/mobile-header";
+import { ResetChat } from "./reset-chat";
 
 interface Props {
   chatThread: ChatThreadModel;
@@ -44,7 +45,9 @@ export const ChatHeader: FC<Props> = (props) => {
               {props.chatThread.name}
             </span>
           </div>
-          
+          {props.chatThread.isTemporary && (
+            <ResetChat disabled={!chat.messages.length} />
+          )}
           {/* Extension detail - always visible on mobile */}
           <ExtensionDetail
             disabled={props.chatDocuments.length !== 0}
@@ -80,7 +83,10 @@ export const ChatHeader: FC<Props> = (props) => {
                 <span className="truncate">{persona}</span>
               </span>
             </div>
-            
+            {props.chatThread.isTemporary && (
+              <ResetChat disabled={!chat.messages.length} />
+            )}
+
             {/* Action buttons */}
             <div className="flex gap-1 shrink-0">
               {/* Hide persona and document details on smaller screens */}

--- a/src/features/chat-page/chat-header/reset-chat.tsx
+++ b/src/features/chat-page/chat-header/reset-chat.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { TEMPORARY_CHAT_ROUTE } from "@/features/theme/theme-config";
+import { Button } from "@/features/ui/button";
+import { RotateCcw } from "lucide-react";
+import { useRouter } from "next/navigation";
+
+export const ResetChat = ({ disabled }: { disabled?: boolean }) => {
+  const router = useRouter();
+
+  return (
+    <Button
+      title="Reset Chat"
+      disabled={disabled}
+      size={"default"}
+      className={`flex gap-2`}
+      variant="outline"
+      onClick={() => router.push(TEMPORARY_CHAT_ROUTE)}
+    >
+      <RotateCcw size={18} />
+    </Button>
+  );
+};

--- a/src/features/chat-page/chat-menu/chat-menu-header.tsx
+++ b/src/features/chat-page/chat-menu/chat-menu-header.tsx
@@ -3,16 +3,19 @@
 import { CreateChatAndRedirect } from "../chat-services/chat-thread-service";
 import { ChatContextMenu } from "./chat-context-menu";
 import { NewChat } from "./new-chat";
+import { TemporaryChat } from "./temporary-chat";
 
 export const ChatMenuHeader = () => {
   return (
     <div className="flex p-2 px-3 justify-between items-center border-b">
       <h2 className="text-sm font-semibold">Chat History</h2>
-      
-      <form action={CreateChatAndRedirect} className="flex gap-2">
-        <NewChat />
+      <div className="flex gap-2">
+        <form action={CreateChatAndRedirect}>
+          <NewChat />
+        </form>
+        <TemporaryChat />
         <ChatContextMenu />
-      </form>
+      </div>
     </div>
   );
 };

--- a/src/features/chat-page/chat-menu/temporary-chat.tsx
+++ b/src/features/chat-page/chat-menu/temporary-chat.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { TEMPORARY_CHAT_ROUTE } from "@/features/theme/theme-config";
+import { Button } from "@/features/ui/button";
+import { Clock } from "lucide-react";
+import { usePathname, useRouter } from "next/navigation";
+
+export const TemporaryChat = () => {
+  const router = useRouter();
+
+  const pathname = usePathname();
+  const isTemporaryChat = pathname === TEMPORARY_CHAT_ROUTE;
+
+  return (
+    <Button
+      title="Temporary Chat"
+      size={"default"}
+      className={`flex gap-2 ${
+        isTemporaryChat ? "text-primary" : ""
+      }`}
+      onClick={() => router.push(TEMPORARY_CHAT_ROUTE)}
+      variant="outline"
+    >
+      <Clock size={18} />
+    </Button>
+  );
+};

--- a/src/features/chat-page/chat-services/models.ts
+++ b/src/features/chat-page/chat-services/models.ts
@@ -269,6 +269,7 @@ export interface ChatThreadModel {
   type: typeof CHAT_THREAD_ATTRIBUTE;
   personaDocumentIds: string[];
   selectedModel?: ChatModel;
+  isTemporary?: boolean;
 }
 
 export interface UserPrompt {

--- a/src/features/theme/theme-config.ts
+++ b/src/features/theme/theme-config.ts
@@ -10,3 +10,6 @@ You have access to the following functions:
 1. create_img: You must only use the function create_img if the user asks you to create an image.`;
 
 export const NEW_CHAT_NAME = "New chat";
+
+export const TEMPORARY_CHAT_NAME = "Temporary Chat";
+export const TEMPORARY_CHAT_ROUTE = '/chat/temporary'


### PR DESCRIPTION
Feat: Temporary chat

- The route is defined and fixed for the user to land to it via the URL
- A new button next to 'New Chat' to land to this page from the app. Is shown active when already on the page.
- Page reload will clear the chat
- Also, a reset button, just for temporary chat page to allow resetting the chat. Only enabled when there is at-least one message.