### PR TITLE
feat: default tools for agents, home page flyout fix, and UI improvem…

### DIFF
--- a/src/components/ai-elements/tool.tsx
+++ b/src/components/ai-elements/tool.tsx
@@ -23,7 +23,7 @@ export type ToolProps = ComponentProps<typeof Collapsible>;
 
 export const Tool = ({ className, ...props }: ToolProps) => (
   <Collapsible
-    className={cn('not-prose mb-4 w-full rounded-md border', className)}
+    className={cn('not-prose mb-2 w-full rounded-md border border-muted', className)}
     {...props}
   />
 );
@@ -122,20 +122,20 @@ export const ToolOutput = ({
   }
 
   return (
-    <div className={cn('space-y-2 p-4', className)} {...props}>
-      <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+    <div className={cn('space-y-1 px-4 pb-3', className)} {...props}>
+      <h4 className="font-medium text-muted-foreground text-[10px] uppercase tracking-wide">
         {errorText ? 'Error' : 'Result'}
       </h4>
       <div
         className={cn(
-          'overflow-x-auto rounded-md text-xs [&_table]:w-full',
+          'overflow-x-auto rounded text-xs max-h-[200px] overflow-y-auto [&_table]:w-full',
           errorText
-            ? 'bg-destructive/10 text-destructive'
-            : 'bg-muted/50 text-foreground'
+            ? 'bg-destructive/10 text-destructive p-2'
+            : 'text-muted-foreground'
         )}
       >
         {errorText && <div>{errorText}</div>}
-        {output && <div>{output}</div>}
+        {output && <div className="line-clamp-[8]">{output}</div>}
       </div>
     </div>
   );

--- a/src/features/chat-home-page/chat-home.tsx
+++ b/src/features/chat-home-page/chat-home.tsx
@@ -2,6 +2,7 @@
 
 import { ExtensionModel } from "@/features/extensions-page/extension-services/models";
 import { AgentList } from "@/features/persona-page/agent-list";
+import { AddNewPersona } from "@/features/persona-page/add-new-persona";
 import { PersonaModel } from "@/features/persona-page/persona-services/models";
 import { AI_DESCRIPTION, AI_NAME } from "@/features/theme/theme-config";
 import { Hero } from "@/features/ui/hero";
@@ -99,7 +100,7 @@ const ArticlesSection = ({
   </div>
 );
 
-export const ChatHome: FC<ChatPersonaProps> = ({ personas, news, favoriteAgentIds, currentUserId }) => {
+export const ChatHome: FC<ChatPersonaProps> = ({ personas, extensions, news, favoriteAgentIds, currentUserId }) => {
   const [showChangelog, setShowChangelog] = useState<boolean>(false);
 
   return (
@@ -137,6 +138,7 @@ export const ChatHome: FC<ChatPersonaProps> = ({ personas, news, favoriteAgentId
             </>
           )}
         </div>
+        <AddNewPersona extensions={extensions} personas={personas} />
       </main>
     </ScrollArea>
   );

--- a/src/features/chat-page/chat-page.tsx
+++ b/src/features/chat-page/chat-page.tsx
@@ -95,22 +95,7 @@ const ChatMessages = memo(function ChatMessages({ profilePicture }: { profilePic
                     })}
                   </div>
                 )}
-                {m.role === 'tool' && (() => {
-                  let parsed: any = null;
-                  try { parsed = JSON.parse(m.content); } catch { /* ignore */ }
-                  const toolName = parsed?.name || m.name || 'tool';
-                  const toolArgs = parsed?.arguments ? (() => { try { return JSON.parse(parsed.arguments); } catch { return parsed.arguments; } })() : undefined;
-                  const toolResult = parsed?.result;
-                  return (
-                    <Tool>
-                      <ToolHeader type={toolName} state={toolResult ? 'output-available' : 'input-available'} />
-                      <ToolContent>
-                        {toolArgs && <ToolInput input={toolArgs} />}
-                        <ToolOutput output={toolResult} errorText={undefined} />
-                      </ToolContent>
-                    </Tool>
-                  );
-                })()}
+                {/* Tool role messages are already rendered via toolHistory on the assistant message above */}
                 {(m.role === 'assistant' || m.role === 'user' || m.role === 'system') && (
                   <RichResponse content={m.content} />
                 )}

--- a/src/features/chat-page/chat-services/chat-api/function-registry.ts
+++ b/src/features/chat-page/chat-services/chat-api/function-registry.ts
@@ -371,11 +371,28 @@ async function callSubAgent(
 
   try {
     const openaiInstance = subAgentModelConfig.getInstance();
-    
+
+    // Build built-in tools from sub-agent persona's defaultTools
+    const dt = subAgent.defaultTools;
+    const builtInTools: any[] = [];
+    if (dt?.imageGeneration) {
+      builtInTools.push({ type: "image_generation" });
+    }
+    if (dt?.webSearch) {
+      builtInTools.push({ type: "web_search_preview" });
+    }
+    if (dt?.codeInterpreter) {
+      builtInTools.push({ type: "code_interpreter", container: { type: "auto" } });
+    }
+
     const requestOptions: any = {
       model: subAgentModelConfig.deploymentName,
       stream: false,
       store: false,
+      ...(builtInTools.length > 0 && {
+        tools: builtInTools,
+        tool_choice: "auto",
+      }),
     };
 
     if (subAgentModelConfig.supportsReasoning) {

--- a/src/features/chat-page/chat-services/models.ts
+++ b/src/features/chat-page/chat-services/models.ts
@@ -181,6 +181,13 @@ export interface AttachedFileModel {
   uploadedAt?: Date;
 }
 
+export interface DefaultTools {
+  webSearch?: boolean;
+  imageGeneration?: boolean;
+  companyContent?: boolean;
+  codeInterpreter?: boolean;
+}
+
 export interface ChatThreadModel {
   id: string;
   name: string;
@@ -202,6 +209,7 @@ export interface ChatThreadModel {
   codeInterpreterFileIdsSignature?: string;
   attachedFiles?: Array<AttachedFileModel>;
   subAgentIds?: string[];
+  defaultTools?: DefaultTools;
 }
 
 export interface UserPrompt {

--- a/src/features/chat-page/chat-store.tsx
+++ b/src/features/chat-page/chat-store.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { uniqueId } from "@/features/common/util";
 import { showError } from "@/features/globals/global-message-store";
-import { AI_NAME, NEW_CHAT_NAME } from "@/features/theme/theme-config";
+import { AI_NAME } from "@/features/theme/theme-config";
 import {
   ParsedEvent,
   ReconnectInterval,
@@ -131,11 +131,12 @@ class ChatState {
       this.tempReasoningContent = "";
       this.currentAssistantMessageId = "";
       
-      // Reset tool states for new chat
-      this.webSearchEnabled = false;
-      this.imageGenerationEnabled = true;
-      this.companyContentEnabled = false;
-      this.codeInterpreterEnabled = false;
+      // Apply default tool states from persona, or use defaults
+      const dt = chatThread.defaultTools;
+      this.webSearchEnabled = dt?.webSearch ?? false;
+      this.imageGenerationEnabled = dt?.imageGeneration ?? true;
+      this.companyContentEnabled = dt?.companyContent ?? false;
+      this.codeInterpreterEnabled = dt?.codeInterpreter ?? false;
       
       // Load attached files from the chat thread
       this.attachedFiles = chatThread.attachedFiles || [];
@@ -459,11 +460,14 @@ class ChatState {
   }
 
   private async updateTitle() {
-    if (this.chatThread && this.chatThread.name === NEW_CHAT_NAME) {
+    // Generate a title after the first user message, regardless of the initial chat name.
+    // This works for both regular chats ("New chat") and agent-based chats (named after the agent).
+    const userMessages = this.messages.filter((m) => m.role === "user");
+    if (this.chatThread && userMessages.length === 1) {
       // Fire-and-forget: update title asynchronously without blocking the UI
       setTimeout(async () => {
         try {
-          await UpdateChatTitle(this.chatThreadId, this.messages[0].content);
+          await UpdateChatTitle(this.chatThreadId, userMessages[0].content);
           RevalidateCache({
             page: "chat",
             type: "layout",

--- a/src/features/persona-page/add-new-persona.tsx
+++ b/src/features/persona-page/add-new-persona.tsx
@@ -31,7 +31,7 @@ import {
 } from "./persona-store";
 import { ExtensionDetail } from "../chat-page/chat-header/extension-detail";
 import { ExtensionModel } from "../extensions-page/extension-services/models";
-import { PersonaModel } from "./persona-services/models";
+import { PersonaModel, DefaultTools } from "./persona-services/models";
 import { PersonaDocuments } from "./persona-documents/persona-documents";
 import { CodeInterpreterDocuments } from "./persona-documents/code-interpreter-documents";
 import { PersonaAccessGroup } from "./persona-access-group/persona-access-group";
@@ -63,13 +63,17 @@ export const AddNewPersona: FC<Props> = (props) => {
   const [selectedSubAgentIds, setSelectedSubAgentIds] = useState<string[]>(
     [...(persona.subAgentIds || [])]
   );
+  const [defaultTools, setDefaultTools] = useState<DefaultTools>(
+    persona.defaultTools || {}
+  );
   const [availableModels, setAvailableModels] = useState<Record<string, ModelConfig>>(MODEL_CONFIGS);
 
   // Reset local state when persona changes
   useEffect(() => {
     setSelectedModel(persona.selectedModel || "__default__");
     setSelectedSubAgentIds([...(persona.subAgentIds || [])]);
-  }, [persona.id, persona.selectedModel, persona.subAgentIds]);
+    setDefaultTools(persona.defaultTools || {});
+  }, [persona.id, persona.selectedModel, persona.subAgentIds, persona.defaultTools]);
 
   useEffect(() => {
     const fetchModels = async () => {
@@ -148,6 +152,11 @@ export const AddNewPersona: FC<Props> = (props) => {
                   name="subAgentIds"
                   value={JSON.stringify(selectedSubAgentIds)}
                 />
+                <input
+                  type="hidden"
+                  name="defaultTools"
+                  value={JSON.stringify(defaultTools)}
+                />
                 <div className="grid gap-2">
                   <Label>Name</Label>
                   <Input
@@ -204,6 +213,58 @@ export const AddNewPersona: FC<Props> = (props) => {
                   <p className="text-xs text-muted-foreground">
                     Optionally set a specific model for this agent. If not set, the model selected by the user at chat time will be used.
                   </p>
+                </div>
+                <div className="grid gap-2">
+                  <Label>Default Tools</Label>
+                  <p className="text-xs text-muted-foreground">
+                    Tools enabled by default when a chat is started with this agent. Users can still toggle them in the chat.
+                  </p>
+                  <div className="flex flex-col gap-2 border rounded-md p-3">
+                    <label className="flex items-center gap-2 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        className="h-4 w-4 rounded border-input"
+                        checked={defaultTools.webSearch ?? false}
+                        onChange={(e) =>
+                          setDefaultTools((prev) => ({ ...prev, webSearch: e.target.checked }))
+                        }
+                      />
+                      <span className="text-sm">Web Search</span>
+                    </label>
+                    <label className="flex items-center gap-2 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        className="h-4 w-4 rounded border-input"
+                        checked={defaultTools.imageGeneration ?? false}
+                        onChange={(e) =>
+                          setDefaultTools((prev) => ({ ...prev, imageGeneration: e.target.checked }))
+                        }
+                      />
+                      <span className="text-sm">Image Generation</span>
+                    </label>
+                    <label className="flex items-center gap-2 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        className="h-4 w-4 rounded border-input"
+                        checked={defaultTools.companyContent ?? false}
+                        onChange={(e) =>
+                          setDefaultTools((prev) => ({ ...prev, companyContent: e.target.checked }))
+                        }
+                      />
+                      <span className="text-sm">Company Content</span>
+                    </label>
+                    <label className="flex items-center gap-2 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        className="h-4 w-4 rounded border-input"
+                        checked={defaultTools.codeInterpreter ?? false}
+                        onChange={(e) =>
+                          setDefaultTools((prev) => ({ ...prev, codeInterpreter: e.target.checked }))
+                        }
+                      />
+                      <span className="text-sm">Code Interpreter</span>
+                    </label>
+                  </div>
                 </div>
                 <div className="grid gap-2">
                   <Label htmlFor="extensionIds[]">Extensions</Label>

--- a/src/features/persona-page/persona-services/models.ts
+++ b/src/features/persona-page/persona-services/models.ts
@@ -61,6 +61,15 @@ export const AccessGroupSchema = z.object({
 export const PERSONA_ATTRIBUTE = "PERSONA";
 export type PersonaModel = z.infer<typeof PersonaModelSchema>;
 
+export const DefaultToolsSchema = z.object({
+  webSearch: z.boolean().optional(),
+  imageGeneration: z.boolean().optional(),
+  companyContent: z.boolean().optional(),
+  codeInterpreter: z.boolean().optional(),
+}).optional();
+
+export type DefaultTools = z.infer<typeof DefaultToolsSchema>;
+
 export const PersonaModelSchema = z.object({
   id: z.string(),
   userId: z.string(),
@@ -91,6 +100,7 @@ export const PersonaModelSchema = z.object({
   accessGroup: AccessGroupSchema.optional(),
   selectedModel: z.string().optional(), // Specific model to use for this agent
   subAgentIds: z.array(z.string()).optional(), // IDs of sub-agents this agent can call
+  defaultTools: DefaultToolsSchema, // Default tool settings for this agent
 });
 
 

--- a/src/features/persona-page/persona-services/persona-service.ts
+++ b/src/features/persona-page/persona-services/persona-service.ts
@@ -18,6 +18,7 @@ import { uniqueId } from "@/features/common/util";
 import { SqlQuerySpec } from "@azure/cosmos";
 import {
   AccessGroup,
+  DefaultTools,
   DocumentMetadata,
   PERSONA_ATTRIBUTE,
   PersonaModel,
@@ -50,6 +51,7 @@ interface PersonaInput {
   codeInterpreterDocumentIds?: string[];
   selectedModel?: string;
   subAgentIds?: string[];
+  defaultTools?: DefaultTools;
 }
 
 export const FindPersonaByID = async (
@@ -150,6 +152,7 @@ export const CreatePersona = async (
       codeInterpreterDocumentIds: props.codeInterpreterDocumentIds || [],
       selectedModel: props.selectedModel,
       subAgentIds: props.subAgentIds || [],
+      defaultTools: props.defaultTools,
     };
 
     const valid = ValidateSchema(modelToSave);
@@ -283,6 +286,7 @@ export const UpsertPersona = async (
         codeInterpreterDocumentIds: personaInput.codeInterpreterDocumentIds || [],
         selectedModel: personaInput.selectedModel,
         subAgentIds: personaInput.subAgentIds || [],
+        defaultTools: personaInput.defaultTools,
       };
 
       const validationResponse = ValidateSchema(modelToUpdate);
@@ -518,6 +522,7 @@ export const CreatePersonaChat = async (
       attachedFiles: attachedFiles.length > 0 ? attachedFiles : undefined,
       selectedModel: persona.selectedModel as ChatModel | undefined,
       subAgentIds: persona.subAgentIds || [],
+      defaultTools: persona.defaultTools,
     });
 
     return response;

--- a/src/features/persona-page/persona-store.ts
+++ b/src/features/persona-page/persona-store.ts
@@ -170,6 +170,11 @@ const FormDataToPersonaModel = (formData: FormData): PersonaModel => {
     ? JSON.parse(subAgentIdsRaw) as string[]
     : [];
 
+  const defaultToolsRaw = formData.get("defaultTools") as string;
+  const defaultTools = defaultToolsRaw
+    ? JSON.parse(defaultToolsRaw)
+    : undefined;
+
   return {
     id: formData.get("id") as string,
     name: formData.get("name") as string,
@@ -188,5 +193,6 @@ const FormDataToPersonaModel = (formData: FormData): PersonaModel => {
     codeInterpreterDocumentIds: codeInterpreterDocumentIds,
     selectedModel: selectedModel,
     subAgentIds: subAgentIds,
+    defaultTools: defaultTools,
   };
 };


### PR DESCRIPTION
…ents

- Allow setting default tools (web search, image generation, code interpreter, company content) per agent, applied when starting a chat and for sub-agents
- Fix agent edit flyout not opening from home screen 3-dot menu
- Fix duplicate tool call rendering in chat messages
- Make tool output display less prominent
- Fix chat title not updating for agent-based chats after first message