### PR TITLE
Fix empty chat boxes from tool output messages

### DIFF
--- a/src/features/chat-page/chat-page.tsx
+++ b/src/features/chat-page/chat-page.tsx
@@ -68,7 +68,7 @@ const ChatMessages = memo(function ChatMessages({ profilePicture }: { profilePic
             </div>
           </div>
         )}
-        {messages.map((m, mIndex) => {
+        {messages.filter(m => m.role !== 'tool' && m.role !== 'function').map((m, mIndex) => {
           const role = (m.role === 'user' || m.role === 'assistant' || m.role === 'system') ? m.role : 'assistant';
           const avatarSrc = role === 'user'
             ? (profilePicture || '/user-icon.png')


### PR DESCRIPTION
## Summary

Fixes #100 — Tool output was creating empty chat boxes at the bottom of the chat thread.

## Root Cause

Tool-role messages (persisted for refresh resilience) were being rendered as standalone `<Message>` components in the chat list. While the inner `<RichResponse>` was conditionally skipped for tool messages, the outer `<Message>` wrapper still rendered — producing empty chat boxes.

## Fix

Filter out `tool` and `function` role messages before mapping over the message list. These messages are already displayed via `toolCallHistory` on the parent assistant message, so they should not render as separate entries.