### PR TITLE
fix: skip rendering tool/function role messages as empty chat boxes

### DIFF
--- a/src/features/chat-page/chat-page.tsx
+++ b/src/features/chat-page/chat-page.tsx
@@ -69,6 +69,8 @@ const ChatMessages = memo(function ChatMessages({ profilePicture }: { profilePic
           </div>
         )}
         {messages.map((m, mIndex) => {
+          // Tool/function messages are rendered via toolHistory on the assistant message — skip them
+          if (m.role === 'tool' || m.role === 'function') return null;
           const role = (m.role === 'user' || m.role === 'assistant' || m.role === 'system') ? m.role : 'assistant';
           const avatarSrc = role === 'user'
             ? (profilePicture || '/user-icon.png')
@@ -111,10 +113,7 @@ const ChatMessages = memo(function ChatMessages({ profilePicture }: { profilePic
                     })}
                   </div>
                 )}
-                {/* Tool role messages are already rendered via toolHistory on the assistant message above */}
-                {(m.role === 'assistant' || m.role === 'user' || m.role === 'system') && (
-                  <RichResponse content={m.content} />
-                )}
+                <RichResponse content={m.content} />
                 </MessageContent>
                 {(m.role === 'assistant' || m.role === 'user') && (
                   <div className="flex group-[.is-user]:justify-end group-[.is-assistant]:justify-start px-0.5">


### PR DESCRIPTION
## Summary

Fixes #100 - Every tool output creates empty chat boxes on the bottom of the chat thread.

## Root Cause

Tool and function role messages were added to the messages array and rendered as separate chat bubbles. However, the content rendering condition only displayed content for assistant, user, and system roles - so tool messages produced visible but empty chat boxes.

These tool outputs are already properly displayed via toolCallHistory on the parent assistant message (as collapsible tool call UI elements).

## Fix

Skip rendering tool and function role messages entirely in the message list loop (chat-page.tsx), since they are already rendered as part of the assistant message's tool call history UI.
