### PR TITLE
fix(chat): show tool call errors instead of eternal "Running" badge

### DIFF
--- a/src/features/chat-page/__tests__/tool-part-view.test.tsx
+++ b/src/features/chat-page/__tests__/tool-part-view.test.tsx
@@ -73,6 +73,48 @@ describe("normalizeToolPart", () => {
     );
     expect(out.state).toBe("output-available");
   });
+
+  it("maps SDK output-error state to output-error, not Running", () => {
+    const out = normalizeToolPart(
+      {
+        type: "tool-comos_search",
+        state: "output-error",
+        input: { query: "x" },
+        errorText: 'Extension "comos_search" failed with status 403',
+      } as never,
+      0,
+    );
+    expect(out.state).toBe("output-error");
+    expect(out.errorText).toBe(
+      'Extension "comos_search" failed with status 403',
+    );
+  });
+
+  it("treats a part with errorText but no state as output-error", () => {
+    const out = normalizeToolPart(
+      { type: "tool-call", input: {}, errorText: "boom" } as never,
+      0,
+    );
+    expect(out.state).toBe("output-error");
+    expect(out.errorText).toBe("boom");
+  });
+
+  it("falls back to a generic error message when output-error has no errorText", () => {
+    const out = normalizeToolPart(
+      { type: "tool-call", state: "output-error", input: {} } as never,
+      0,
+    );
+    expect(out.state).toBe("output-error");
+    expect(out.errorText).toBe("Tool call failed");
+  });
+
+  it("leaves errorText undefined for successful parts", () => {
+    const out = normalizeToolPart(
+      { type: "tool-call", output: { hits: [] } } as never,
+      0,
+    );
+    expect(out.errorText).toBeUndefined();
+  });
 });
 
 describe("renderToolOutput", () => {

--- a/src/features/chat-page/chat-page.tsx
+++ b/src/features/chat-page/chat-page.tsx
@@ -304,7 +304,7 @@ const ChatMessages = memo(function ChatMessages({ profilePicture }: { profilePic
           user (architect2 SEV-1 B6).
         */}
         {error && (
-          <div className="flex items-center gap-3 py-4 px-4 mx-auto max-w-md rounded-md bg-destructive/10 border border-destructive/30 text-destructive-foreground text-sm">
+          <div className="flex items-center gap-3 py-4 px-4 mx-auto max-w-md rounded-md bg-destructive/10 border border-destructive/30 text-foreground text-sm">
             <span>
               {error instanceof Error ? error.message : String(error)}
             </span>

--- a/src/features/chat-page/tool-part-view.tsx
+++ b/src/features/chat-page/tool-part-view.tsx
@@ -51,9 +51,13 @@ interface NormalizedToolPart {
   /**
    * The Tool component's state input. Mapped from AI SDK part type +
    * presence of `output` so we never show a "Running" widget for a part
-   * that already has a result.
+   * that already has a result — including failed parts, which carry
+   * `errorText` but no `output` and must surface as "Error", not an
+   * eternally-running widget.
    */
-  state: "input-available" | "output-available";
+  state: "input-available" | "output-available" | "output-error";
+  /** Error message when the tool call failed (AI SDK `output-error` parts). */
+  errorText: string | undefined;
 }
 
 /**
@@ -86,6 +90,7 @@ export function normalizeToolPart(
     input?: unknown;
     output?: unknown;
     state?: string;
+    errorText?: string;
   };
 
   // For `tool-<name>` parts the toolName isn't a separate field — derive
@@ -97,11 +102,14 @@ export function normalizeToolPart(
       : "tool");
 
   const hasOutput = p.output !== undefined && p.output !== null;
-  const state: NormalizedToolPart["state"] = hasOutput
-    ? "output-available"
-    : p.state === "output-available"
+  const hasError = p.state === "output-error" || p.errorText !== undefined;
+  const state: NormalizedToolPart["state"] = hasError
+    ? "output-error"
+    : hasOutput
       ? "output-available"
-      : "input-available";
+      : p.state === "output-available"
+        ? "output-available"
+        : "input-available";
 
   return {
     id: p.toolCallId ?? `idx-${index}`,
@@ -109,6 +117,7 @@ export function normalizeToolPart(
     input: p.input,
     output: p.output ?? null,
     state,
+    errorText: hasError ? (p.errorText ?? "Tool call failed") : undefined,
   };
 }
 
@@ -254,7 +263,9 @@ export function renderToolOutput(output: unknown, toolName?: string): ReactNode 
 export function ToolPartView({ part, index }: { part: UIMessagePart; index: number }) {
   const normalized = normalizeToolPart(part, index);
   return (
-    <Tool>
+    // Failed calls open expanded so the error message is visible without a
+    // click; successful calls stay collapsed as before.
+    <Tool defaultOpen={normalized.state === "output-error"}>
       <ToolHeader
         type={`tool-${normalized.toolName}` as `tool-${string}`}
         state={normalized.state}
@@ -263,7 +274,7 @@ export function ToolPartView({ part, index }: { part: UIMessagePart; index: numb
         <ToolInput input={normalized.input} />
         <ToolOutput
           output={renderToolOutput(normalized.output, normalized.toolName)}
-          errorText={undefined}
+          errorText={normalized.errorText}
         />
       </ToolContent>
     </Tool>


### PR DESCRIPTION
## Problem
When an extension/tool call failed (e.g. the COMOS & PES user-manual searches with missing Key Vault secrets), the tool widget showed a pulsing "Running" badge forever even though the answer was already generated, and the error message was never displayed.

## Fix
- `normalizeToolPart` maps AI SDK `output-error` state / `errorText` to an error state instead of collapsing it to `input-available`
- `errorText` is passed through to `ToolOutput` (red error panel) instead of hard-coded `undefined`
- Failed tool widgets render expanded by default so the error is visible without a click
- Bonus: chat error banner uses readable foreground color

## Tests
24/24 unit tests incl. 4 new error-state cases.