### PR TITLE
fix(chat): only auto-close reasoning panel after a real streaming transition

### DIFF
--- a/src/__tests__/e2e-fakes/azure-provider.ts
+++ b/src/__tests__/e2e-fakes/azure-provider.ts
@@ -103,9 +103,13 @@ function makeFinishReason(unified: "stop" | "tool-calls" | "error" = "stop") {
 }
 
 // Build a ReadableStream from an array of LanguageModelV3StreamPart objects.
-// text-delta parts are paced so abort-mid-stream specs have time to click
-// the stop button before the stream finishes. Other part types flush
-// immediately so the test runtime stays bounded.
+// text-delta and reasoning-delta parts are paced so the client paints
+// intermediate streaming frames: abort-mid-stream specs need time to click
+// the stop button, and the reasoning panel needs a "reasoning is the last
+// part" frame to open before the answer arrives (otherwise React coalesces
+// the whole stream into one render and the panel never opens). Other part
+// types flush immediately so the test runtime stays bounded.
+const PACED_PART_TYPES = new Set(["text-delta", "reasoning-delta"]);
 function chunkStream(parts: unknown[]): ReadableStream<unknown> {
   return new ReadableStream({
     async start(controller) {
@@ -114,7 +118,7 @@ function chunkStream(parts: unknown[]): ReadableStream<unknown> {
         if (
           typeof part === "object" &&
           part !== null &&
-          (part as { type?: string }).type === "text-delta"
+          PACED_PART_TYPES.has((part as { type?: string }).type ?? "")
         ) {
           await new Promise((r) => setTimeout(r, 20));
         }

--- a/src/components/ai-elements/reasoning.tsx
+++ b/src/components/ai-elements/reasoning.tsx
@@ -62,6 +62,7 @@ export const Reasoning = memo(
     });
 
     const [hasAutoClosedRef, setHasAutoClosedRef] = useState(false);
+    const [hasStreamed, setHasStreamed] = useState(false);
     const [startTime, setStartTime] = useState<number | null>(null);
 
     // Track duration when streaming starts and ends
@@ -76,9 +77,22 @@ export const Reasoning = memo(
       }
     }, [isStreaming, startTime, setDuration]);
 
-    // Auto-open when streaming starts, auto-close when streaming ends (once only)
+    // Remember that reasoning actually streamed in this session so we can
+    // auto-close once it ends. We can't gate the close on `defaultOpen`: the
+    // caller flips `defaultOpen`/`isStreaming` to false together the instant
+    // the answer text begins, so a `defaultOpen` guard would never fire.
     useEffect(() => {
-      if (defaultOpen && !isStreaming && isOpen && !hasAutoClosedRef) {
+      if (isStreaming) {
+        setHasStreamed(true);
+      }
+    }, [isStreaming]);
+
+    // Auto-close once, shortly after reasoning streaming ends, so the user
+    // sees where reasoning stops and the answer begins. Only triggers after a
+    // real streaming→done transition — historical or manually-opened panels
+    // (which never streamed) are left untouched.
+    useEffect(() => {
+      if (hasStreamed && !isStreaming && isOpen && !hasAutoClosedRef) {
         // Add a small delay before closing to allow user to see the content
         const timer = setTimeout(() => {
           setIsOpen(false);
@@ -87,7 +101,7 @@ export const Reasoning = memo(
 
         return () => clearTimeout(timer);
       }
-    }, [isStreaming, isOpen, defaultOpen, setIsOpen, hasAutoClosedRef]);
+    }, [hasStreamed, isStreaming, isOpen, setIsOpen, hasAutoClosedRef]);
 
     const handleOpenChange = (newOpen: boolean) => {
       setIsOpen(newOpen);

--- a/src/e2e/reasoning-autoclose.spec.ts
+++ b/src/e2e/reasoning-autoclose.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "@playwright/test";
+import { scriptReasoning, newThreadUrl } from "./_helpers/script-fake";
+
+// Long enough that the paced reasoning-delta stream (20ms/word) gives the
+// client several frames where reasoning is the last streaming part, so the
+// Reasoning panel actually opens before the answer arrives.
+const REASONING_TEXT =
+  "Let me think about this step by step before I answer the question carefully and thoroughly.";
+const FINAL_ANSWER = "The answer is 42.";
+
+test.describe("reasoning auto-close", () => {
+  test.setTimeout(60_000); // cold-start tail safety; see abort-stream.spec.ts
+
+  test("reasoning panel opens while thinking, then collapses once the answer is complete", async ({
+    page,
+  }) => {
+    const threadUrl = await newThreadUrl(page);
+    await scriptReasoning(page, REASONING_TEXT, FINAL_ANSWER);
+
+    await page.goto(threadUrl);
+    const textarea = page.getByPlaceholder("Type your message...").first();
+    await expect(textarea).toBeVisible({ timeout: 30_000 });
+
+    await textarea.fill("What is the meaning of life?");
+    await page.keyboard.press("Enter");
+
+    const assistantBubble = page.locator(".is-assistant");
+    await expect(assistantBubble).toHaveCount(1, { timeout: 10_000 });
+
+    // The Reasoning trigger is a Radix CollapsibleTrigger; aria-expanded is
+    // the unambiguous open/closed signal (independent of mount/hidden quirks).
+    const reasoningTrigger = assistantBubble.locator(
+      'button[aria-expanded][data-state]',
+    );
+
+    // While the model is thinking, the panel must be OPEN.
+    await expect(reasoningTrigger).toHaveAttribute("aria-expanded", "true", {
+      timeout: 10_000,
+    });
+
+    // Answer renders — reasoning streaming has ended.
+    await expect(page.getByText(FINAL_ANSWER)).toBeVisible({ timeout: 15_000 });
+
+    // The fix: once reasoning streaming ends, the panel auto-collapses
+    // (AUTO_CLOSE_DELAY is 1s; allow margin) so the user sees where reasoning
+    // stops and the answer begins.
+    await expect(reasoningTrigger).toHaveAttribute("aria-expanded", "false", {
+      timeout: 6_000,
+    });
+
+    // The trigger itself stays — it collapsed, it didn't vanish — and shows the
+    // completed label.
+    await expect(
+      assistantBubble.getByText(/Thought for \d+|Thought process/),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+});


### PR DESCRIPTION
## Problem
The reasoning panel auto-close gated on `defaultOpen`, which the caller flips to false together with `isStreaming` the instant answer text begins — so the close never fired; historical panels were also affected.

## Fix
Track "has actually streamed" state; only a real streaming→done transition auto-closes. Historical or manually-opened panels stay open. E2E fake paces `reasoning-delta` parts so the client paints the intermediate frame.

## Tests
New Playwright spec `e2e/reasoning-autoclose.spec.ts`.