### PR TITLE
feat(metrics): re-wire GPT Usage workbook metrics; persist tool results from all steps

### DIFF
--- a/src/features/chat-page/chat-services/chat-api/__tests__/background-completion.test.ts
+++ b/src/features/chat-page/chat-services/chat-api/__tests__/background-completion.test.ts
@@ -37,6 +37,15 @@ vi.mock("@/features/common/services/logger", () => ({
   logError: vi.fn(),
   logWarn: vi.fn(),
 }));
+// persistThread's atomic-batch path calls HistoryContainer().items.batch();
+// unmocked it drives the real Cosmos SDK against the fake test endpoint and its
+// retry/backoff exceeds the 5s test timeout. Reject batch so the sequential
+// UpsertChatMessage fallback (stubbed above) runs deterministically.
+vi.mock("@/features/common/services/cosmos", () => ({
+  HistoryContainer: () => ({
+    items: { batch: vi.fn(async () => { throw new Error("batch unavailable in test"); }) },
+  }),
+}));
 
 // A LanguageModelV3 that streams `words` with `delayMs` between each delta.
 function makeSlowModel(words: string[], delayMs: number) {

--- a/src/features/chat-page/chat-services/chat-api/__tests__/persist-assistant.test.ts
+++ b/src/features/chat-page/chat-services/chat-api/__tests__/persist-assistant.test.ts
@@ -31,6 +31,19 @@ vi.mock("@/features/common/services/usage-service", () => ({
   IncrementUsage: (...a: unknown[]) => mockIncrementUsage(...a),
 }));
 
+// ── Cosmos ────────────────────────────────────────────────────────────────────
+// persistThread's atomic-turn path calls HistoryContainer().items.batch(); left
+// unmocked it drives the real Cosmos SDK against the fake test endpoint, whose
+// retry/backoff blows past the 5s test timeout. Make batch reject so the
+// documented sequential-upsert fallback (UpsertChatMessage, mocked above) runs —
+// the path these tests assert on.
+const mockBatch = vi.fn(async () => {
+  throw new Error("batch unavailable in test");
+});
+vi.mock("@/features/common/services/cosmos", () => ({
+  HistoryContainer: () => ({ items: { batch: (...a: unknown[]) => mockBatch(...a) } }),
+}));
+
 import { persistThread } from "../persist-assistant";
 import { MODEL_CONFIGS } from "../../models";
 import type { UIMessage } from "ai";

--- a/src/features/chat-page/chat-services/chat-api/persist-assistant.ts
+++ b/src/features/chat-page/chat-services/chat-api/persist-assistant.ts
@@ -29,6 +29,12 @@ import { createIdGenerator } from "ai";
 import { userHashedId } from "@/features/auth-page/helpers";
 import { logError, logInfo, logWarn } from "@/features/common/services/logger";
 import { IncrementUsage } from "@/features/common/services/usage-service";
+import {
+  reportPromptTokens,
+  reportCompletionTokens,
+  reportCachedTokens,
+  reportUserChatMessage,
+} from "@/features/common/services/chat-metrics-service";
 import { UpsertChatMessage } from "../chat-message-service";
 import { UpdateChatThreadUsage } from "../chat-thread-service";
 import { HistoryContainer } from "@/features/common/services/cosmos";
@@ -329,6 +335,30 @@ export async function persistThread({
       error: err instanceof Error ? err.message : String(err),
     })
   );
+
+  // Emit App Insights custom metrics (OpenTelemetry) consumed by the
+  // "Bühler GPT Usage" monitoring workbook. These were dropped when the
+  // legacy orchestrator stack was removed (commit 8f818d6); the streamText
+  // finish path replaced them with the Cosmos-only IncrementUsage above.
+  // Re-wired here (fire-and-forget) so the workbook's per-model token /
+  // cache / user tiles keep populating. chatModel/email/name are resolved
+  // from the session inside chat-metrics-service.
+  const model = modelConfig.id;
+  const metricAttrs = { threadId };
+  Promise.all([
+    reportPromptTokens(inputTokens, model, "user", metricAttrs),
+    reportCompletionTokens(outputTokens, model, {
+      ...metricAttrs,
+      totalTokens: inputTokens + outputTokens,
+      inputTokens,
+    }),
+    reportCachedTokens(cachedTokens, model, metricAttrs),
+    reportUserChatMessage(model, metricAttrs),
+  ]).catch((err: unknown) =>
+    logError("Failed to emit chat usage metrics", {
+      error: err instanceof Error ? err.message : String(err),
+    })
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -440,9 +470,24 @@ export async function persistAssistantFromFinishEvent<TOOLS extends ToolSet>({
   // Cosmos row → the UI renders nothing and the user thinks they hit a
   // ghost (architect2 SEV-1 B4). Inject a visible "no content" text part
   // so polling stops, the bubble renders, and the failure is auditable.
+  // streamText's onFinish `event.toolResults` is ONLY the LAST step's tool
+  // results (AI SDK semantics — index.d.ts: "results of the tool calls from
+  // the last step"). A client-executed custom tool such as get_current_time
+  // resolves in a NON-final step — the model needs a later step to turn the
+  // result into prose — so its result never appears in event.toolResults and
+  // was silently dropped from persistence: the tool card rendered live but
+  // vanished on reload. Provider-executed built-in tools (web_search,
+  // code_interpreter, image_generation) resolve within the final step, which
+  // is why only custom-tool cards disappeared. Aggregate across ALL steps,
+  // mirroring the onAbort persist path in route.ts.
+  const allToolResults =
+    event.steps && event.steps.length > 0
+      ? event.steps.flatMap((s) => s.toolResults)
+      : event.toolResults;
+
   const hasText = !!event.text;
   const hasReasoning = !!event.reasoningText;
-  const hasTools = event.toolResults.length > 0;
+  const hasTools = allToolResults.length > 0;
   const isEmptyFinish = !hasText && !hasReasoning && !hasTools;
   if (isEmptyFinish) {
     logWarn("persistAssistantFromFinishEvent: empty finish — writing sentinel row", {
@@ -465,21 +510,21 @@ export async function persistAssistantFromFinishEvent<TOOLS extends ToolSet>({
   // details; pre-migration this was handled by processMessageForImagePersistence
   // running on assistant `content`, which no longer sees the image bytes
   // now that they live in a structured tool output.
+  // TypedToolResult<TOOLS> (both the static and dynamic union members)
+  // already exposes toolName/toolCallId/input/output, so it satisfies
+  // ingestImageGenerationResults' structural parameter directly — no cast
+  // needed. The generic flows through, so the result stays typed as
+  // TypedToolResult<TOOLS>[] for buildAssistantUIMessage too.
   const ingestedToolResults = await ingestImageGenerationResults(
     threadId,
-    event.toolResults as unknown as {
-      toolName: string;
-      toolCallId?: string;
-      input?: unknown;
-      output?: unknown;
-    }[],
+    allToolResults,
   );
 
   const assistant = buildAssistantUIMessage(
     {
       text: isEmptyFinish ? sentinelText : event.text,
       reasoningText: event.reasoningText,
-      toolResults: ingestedToolResults as typeof event.toolResults,
+      toolResults: ingestedToolResults,
     },
     messageId ?? assistantMessageIdGenerator(),
     reasoningDurationMs,

--- a/src/features/common/services/chat-metrics-service.test.ts
+++ b/src/features/common/services/chat-metrics-service.test.ts
@@ -77,6 +77,31 @@ describe("common.unit.chat-metrics — reportCompletionTokens", () => {
   });
 });
 
+describe("common.unit.chat-metrics — reportCachedTokens", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("common.unit.chat-metrics.007: creates cachedTokensUsed histogram and records with default attributes", async () => {
+    const { reportCachedTokens } = await import("./chat-metrics-service");
+    await reportCachedTokens(200, "gpt-4");
+    expect(mockCreateHistogram).toHaveBeenCalledWith("cachedTokensUsed", expect.any(Object));
+    expect(mockRecord).toHaveBeenCalledWith(
+      200,
+      expect.objectContaining({ email: "user@example.com", chatModel: "gpt-4" })
+    );
+  });
+
+  it("common.unit.chat-metrics.008: merges extra attributes for cached tokens", async () => {
+    const { reportCachedTokens } = await import("./chat-metrics-service");
+    await reportCachedTokens(64, "gpt-4", { threadId: "thread-9" });
+    expect(mockRecord).toHaveBeenCalledWith(
+      64,
+      expect.objectContaining({ threadId: "thread-9" })
+    );
+  });
+});
+
 describe("common.unit.chat-metrics — reportUserChatMessage", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/features/common/services/chat-metrics-service.ts
+++ b/src/features/common/services/chat-metrics-service.ts
@@ -47,6 +47,20 @@ export async function reportCompletionTokens(tokenCount: number, model: string, 
         completionsTokensUsed.record(tokenCount, combinedAttributes);
 }
 
+export async function reportCachedTokens(tokenCount: number, model: string, attributes: any = {}) {
+
+    const meter = getChatMeter();
+
+    const cachedTokensUsed = meter.createHistogram("cachedTokensUsed", {
+        description: "Number of prompt tokens served from the model's prompt cache",
+        unit: "tokens",
+    });
+
+    let combinedAttributes = { ...attributes, ...await getAttributes(model) };
+
+    cachedTokensUsed.record(tokenCount, combinedAttributes);
+}
+
 export async function reportUserChatMessage(model: string, attributes: any = {}) {
 
     const meter = getChatMeter();


### PR DESCRIPTION
## Changes
1. **Re-emit App Insights custom metrics** (`promptTokensUsed`, `completionsTokensUsed`, cached tokens, `userChatMessage`) from the streamText finish path. These feed the "Buhler GPT Usage" workbook and were dropped with the legacy orchestrator removal (8f818d6).
2. **Persist tool results from ALL steps**: `onFinish.toolResults` only contains the last step (AI SDK semantics), so client-executed custom tools resolving in earlier steps rendered live but vanished on reload.

## Tests
14/14 across chat-metrics-service, persist-assistant, background-completion.