### PR TITLE
fix(embed): request Storage Access under login click; single-shot auth message

### DIFF
--- a/src/features/embed/embed-sign-in.tsx
+++ b/src/features/embed/embed-sign-in.tsx
@@ -15,6 +15,34 @@ import {
 export const EMBED_AUTH_MESSAGE = "buhler-chat-auth";
 
 /**
+ * Best-effort Storage Access API request. Under the click gesture this asks
+ * the browser to grant the iframe access to its first-party cookies. After a
+ * grant the post-popup reload's request to /embed/* will carry the session
+ * cookie the popup just set, even in browsers that block third-party cookies
+ * by default (Safari ITP, Firefox ETP, Chrome with 3PC off).
+ *
+ * Silently no-ops when:
+ *   - the iframe is already first-party (most dev setups), or
+ *   - the browser doesn't implement the API, or
+ *   - the user declines the prompt — we still fall through to the popup login
+ *     and the "Open in full app" fallback documented in docs/embedding.md.
+ */
+async function requestStorageAccessIfNeeded(): Promise<void> {
+  if (typeof document === "undefined") return;
+  const doc = document as Document & {
+    hasStorageAccess?: () => Promise<boolean>;
+    requestStorageAccess?: () => Promise<void>;
+  };
+  if (!doc.requestStorageAccess) return;
+  try {
+    if (doc.hasStorageAccess && (await doc.hasStorageAccess())) return;
+    await doc.requestStorageAccess();
+  } catch {
+    /* declined / unsupported — fall through to standard popup-cookie path */
+  }
+}
+
+/**
  * Auth-gated placeholder shown inside the iframe when there is no session.
  * Deliberately reveals NOTHING about the agent (name/description) until the
  * user signs in. Microsoft Entra blocks its login pages inside iframes, so we
@@ -22,7 +50,10 @@ export const EMBED_AUTH_MESSAGE = "buhler-chat-auth";
  * to re-check the session.
  */
 export const EmbedSignIn: FC<{ title?: string }> = ({ title }) => {
-  const openLogin = useCallback(() => {
+  const openLogin = useCallback(async () => {
+    // Must run under the click handler (user gesture) — the Storage Access API
+    // refuses outside of one. Best-effort: we still open the popup either way.
+    await requestStorageAccessIfNeeded();
     const callbackUrl =
       typeof window !== "undefined" ? window.location.href : "/";
     const url = `/embed/auth/start?callbackUrl=${encodeURIComponent(callbackUrl)}`;
@@ -33,9 +64,11 @@ export const EmbedSignIn: FC<{ title?: string }> = ({ title }) => {
     const onMessage = (e: MessageEvent) => {
       // Only trust same-origin messages from our own popup.
       if (e.origin !== window.location.origin) return;
-      if (e.data?.type === EMBED_AUTH_MESSAGE && e.data?.status === "ok") {
-        window.location.reload();
-      }
+      if (e.data?.type !== EMBED_AUTH_MESSAGE || e.data?.status !== "ok") return;
+      // Remove the listener before reloading — anti-replay per the OAuth 2.0
+      // Web Message Response Mode draft (single-shot delivery).
+      window.removeEventListener("message", onMessage);
+      window.location.reload();
     };
     window.addEventListener("message", onMessage);
     return () => window.removeEventListener("message", onMessage);


### PR DESCRIPTION
## Problem
Browsers blocking third-party cookies (Safari ITP, Firefox ETP, Chrome with 3PC off) never let the SharePoint-embedded iframe see the session the popup login created — the documented login loop in `docs/embedding.md`.

## Fix
- Call `document.requestStorageAccess()` under the login click gesture (best-effort; falls through to popup + "Open in full app" when declined/unsupported)
- Remove the popup message listener before reloading (single-shot delivery, anti-replay)