### PR TITLE
chore: raise tool step limit to 15; align manifest dev-deps with lockfile

### DIFF
--- a/src/app/(authenticated)/api/chat/route.ts
+++ b/src/app/(authenticated)/api/chat/route.ts
@@ -346,7 +346,7 @@ export async function POST(req: Request) {
     system,
     messages: await convertToModelMessages(ctx.history),
     tools: allTools,
-    stopWhen: stepCountIs(8),
+    stopWhen: stepCountIs(15),
     abortSignal: abortController.signal,
     experimental_transform: (() => {
       // Shared map populated by the code-interpreter rewriter when it

--- a/src/package.json
+++ b/src/package.json
@@ -86,6 +86,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.3",
     "@playwright/test": "^1.60.0",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
@@ -104,6 +105,7 @@
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.18",
     "typescript": "^5.9.3",
+    "vite": "^7.3.5",
     "vitest": "^4.1.6"
   }
 }


### PR DESCRIPTION
- `stopWhen` 8 → 15 steps so longer multi-tool chains (extension searches + sub-agents) can complete
- Declare `@testing-library/dom` and `vite` peer dev-deps in `package.json` (already present in lockfile)