### PR TITLE
feat(models): add Foundry partner models — Claude, Grok, DeepSeek

### DIFF
--- a/src/features/chat-page/chat-services/models.ts
+++ b/src/features/chat-page/chat-services/models.ts
@@ -16,7 +16,11 @@ export type ChatModel =
   | "gpt-5.5"
   | "gpt-5.4"
   | "gpt-5.4-mini"
-  | "gpt-5.3-chat";
+  | "gpt-5.3-chat"
+  | "claude-opus-4-8"
+  | "claude-sonnet-4-6"
+  | "grok-4.3"
+  | "deepseek-v4-pro";
 
 export interface ModelPricing {
   inputPerMillion: number;
@@ -111,6 +115,66 @@ export const MODEL_CONFIGS: Record<ChatModel, ModelConfig> = {
     pricing: { inputPerMillion: 1.75, outputPerMillion: 14.00, cachedInputPerMillion: 0.175 },
     contextWindow: 128000,
     fallbackModel: "gpt-5.4-mini",
+  },
+  // --- Foundry partner models (multi-model testing) -----------------------
+  // Claude is served via the Anthropic-native Messages API on
+  // *.services.ai.azure.com/anthropic — NOT the OpenAI-compatible endpoint.
+  // provider: "anthropic" routes these through the @ai-sdk/anthropic branch
+  // in provider-seam.ts. Grok/DeepSeek go through the standard
+  // OpenAI-compatible /openai/v1 endpoint like the gpt-5.* models.
+  "claude-opus-4-8": {
+    id: "claude-opus-4-8",
+    name: "Claude Opus 4.8",
+    description: "Anthropic's most intelligent Opus model for coding and agents (preview)",
+    getInstance: () => OpenAIV1Instance(), // unused for anthropic-provider models
+    supportsReasoning: true,
+    supportsResponsesAPI: false,
+    provider: "anthropic",
+    deploymentName: process.env.AZURE_ANTHROPIC_OPUS48_DEPLOYMENT_NAME,
+    // Opus 4.8 defaults to effort=high server-side; we forward the user's
+    // selection via providerOptions.anthropic.effort in provider-seam.ts.
+    defaultReasoningEffort: "high",
+    pricing: { inputPerMillion: 5, outputPerMillion: 25.00, cachedInputPerMillion: 0.5 },
+    contextWindow: 1000000,
+  },
+  "claude-sonnet-4-6": {
+    id: "claude-sonnet-4-6",
+    name: "Claude Sonnet 4.6",
+    description: "Anthropic's frontier intelligence at scale for coding and agents (preview)",
+    getInstance: () => OpenAIV1Instance(), // unused for anthropic-provider models
+    supportsReasoning: true,
+    supportsResponsesAPI: false,
+    provider: "anthropic",
+    deploymentName: process.env.AZURE_ANTHROPIC_SONNET46_DEPLOYMENT_NAME,
+    defaultReasoningEffort: "medium",
+    pricing: { inputPerMillion: 3, outputPerMillion: 15.00, cachedInputPerMillion: 0.3 },
+    contextWindow: 1000000,
+  },
+  "grok-4.3": {
+    id: "grok-4.3",
+    name: "Grok 4.3",
+    description: "xAI's Grok 4.3 model (preview)",
+    getInstance: () => OpenAIV1Instance(),
+    supportsReasoning: false,
+    supportsResponsesAPI: true,
+    deploymentName: process.env.AZURE_OPENAI_API_GROK43_DEPLOYMENT_NAME,
+    // TODO: verify Foundry pricing for grok-4.3 — placeholder from grok-4 tier.
+    pricing: { inputPerMillion: 3, outputPerMillion: 15.00, cachedInputPerMillion: 0.75 },
+    contextWindow: 256000,
+  },
+  "deepseek-v4-pro": {
+    id: "deepseek-v4-pro",
+    name: "DeepSeek V4 Pro",
+    description: "DeepSeek V4 Pro model (preview). Reasoning output may be intermittent.",
+    getInstance: () => OpenAIV1Instance(),
+    // Foundry caveat: the reasoning output item is emitted on only ~half of
+    // requests and reasoning_tokens reports 0 — keep reasoning off in the UI.
+    supportsReasoning: false,
+    supportsResponsesAPI: true,
+    deploymentName: process.env.AZURE_OPENAI_API_DEEPSEEK_V4_DEPLOYMENT_NAME,
+    // TODO: verify Foundry pricing for DeepSeek-V4-Pro — placeholder.
+    pricing: { inputPerMillion: 1.2, outputPerMillion: 5.00, cachedInputPerMillion: 0.3 },
+    contextWindow: 128000,
   },
 };
 

--- a/src/features/chat-page/chat-services/models/provider-seam.ts
+++ b/src/features/chat-page/chat-services/models/provider-seam.ts
@@ -30,7 +30,9 @@
 
 import type { LanguageModelV3, JSONValue } from "@ai-sdk/provider";
 import { azure } from "@ai-sdk/azure";
+import { createAnthropic } from "@ai-sdk/anthropic";
 import { resolveAzureModel } from "./provider";
+import { getAzureAiFoundryTokenProvider } from "@/features/common/services/azure-default-credential";
 import {
   MODEL_CONFIGS,
   type ChatModel,
@@ -117,19 +119,96 @@ export function resolveProvider(args: ResolveProviderArgs): ResolvedProvider {
     case "azure":
       return resolveAzureBackedProvider(args);
     case "anthropic":
-      // Reserved for the follow-up Anthropic PR. Throw a descriptive
-      // error rather than silently fall back, so the missing wiring is
-      // surfaced when the user first picks an Anthropic model.
-      throw new Error(
-        `resolveProvider: model "${args.modelId}" is provider="anthropic", ` +
-          `but the Anthropic seam is not yet wired. Install @ai-sdk/anthropic ` +
-          `and implement the anthropic branch in provider-seam.ts.`
-      );
+      return resolveAnthropicBackedProvider(args, config);
     default:
       throw new Error(
         `resolveProvider: unhandled provider "${providerTag}" for model "${args.modelId}"`
       );
   }
+}
+
+/**
+ * Anthropic Claude served by Azure AI Foundry.
+ *
+ * Foundry exposes Claude via the Anthropic-NATIVE Messages API at
+ *   https://<resource>.services.ai.azure.com/anthropic/v1/messages
+ * (NOT the OpenAI-compatible /openai/v1 endpoint), so we use
+ * @ai-sdk/anthropic with a custom baseURL instead of @ai-sdk/azure.
+ *
+ * Auth, in precedence order (mirrors the Azure provider):
+ *   1. AZURE_ANTHROPIC_API_KEY → sent as `x-api-key` by the SDK.
+ *   2. Entra ID via DefaultAzureCredential with the FOUNDRY scope
+ *      `https://ai.azure.com/.default` (cognitive-services scope is
+ *      rejected on *.services.ai.azure.com). A fetch wrapper swaps the
+ *      placeholder x-api-key for `Authorization: Bearer <token>`.
+ *
+ * Model-specific constraints baked in here (per Anthropic's Foundry docs,
+ * verified 2026-06-03):
+ *   - Opus 4.8 / 4.7 reject temperature/top_p/top_k with 400 — the route
+ *     never sends sampling params, so nothing to strip.
+ *   - thinking: Opus 4.8 supports only `adaptive`/`disabled`; Sonnet 4.6
+ *     also `enabled`. We always send `adaptive` and let the model decide.
+ *   - effort: low/medium/high (+ max/xhigh on 4.6+). Mapped from the
+ *     user's ReasoningEffort selection; "minimal" maps to "low".
+ *   - No Azure-native built-in tools here: web search / code interpreter /
+ *     image generation are Responses-API features. Custom tools (RAG,
+ *     extensions, sub-agents) flow through as standard tool calls.
+ */
+function resolveAnthropicBackedProvider(
+  args: ResolveProviderArgs,
+  config: ModelConfig,
+): ResolvedProvider {
+  const deploymentName = config.deploymentName;
+  if (!deploymentName) {
+    throw new Error(
+      `resolveProvider: no deploymentName configured for anthropic model ` +
+        `"${args.modelId}". Check the AZURE_ANTHROPIC_*_DEPLOYMENT_NAME env var.`,
+    );
+  }
+
+  const resourceName =
+    process.env.AZURE_ANTHROPIC_RESOURCE_NAME ??
+    process.env.AZURE_OPENAI_API_INSTANCE_NAME;
+  if (!resourceName) {
+    throw new Error(
+      "resolveProvider(anthropic): neither AZURE_ANTHROPIC_RESOURCE_NAME nor " +
+        "AZURE_OPENAI_API_INSTANCE_NAME is set.",
+    );
+  }
+  const baseURL = `https://${resourceName}.services.ai.azure.com/anthropic/v1`;
+
+  const apiKey = process.env.AZURE_ANTHROPIC_API_KEY;
+  const anthropic = apiKey
+    ? createAnthropic({ baseURL, apiKey })
+    : (() => {
+        const getToken = getAzureAiFoundryTokenProvider();
+        const aadFetch: typeof fetch = async (input, init) => {
+          const token = await getToken();
+          const headers = new Headers(init?.headers);
+          headers.delete("x-api-key");
+          headers.set("Authorization", `Bearer ${token}`);
+          return fetch(input, { ...init, headers });
+        };
+        // Placeholder key satisfies the SDK's loadApiKey check; aadFetch
+        // replaces authentication at call time (same trick as provider.ts).
+        return createAnthropic({ baseURL, apiKey: " ", fetch: aadFetch });
+      })();
+
+  const anthropicOptions: Record<string, JSONValue> = {
+    // Let Claude decide whether/how much to think — supported across
+    // Opus 4.8 (adaptive/disabled only) and Sonnet 4.6.
+    thinking: { type: "adaptive" },
+  };
+  if (args.reasoning.supported && args.reasoning.effort) {
+    anthropicOptions.effort =
+      args.reasoning.effort === "minimal" ? "low" : args.reasoning.effort;
+  }
+
+  return {
+    model: anthropic(deploymentName),
+    builtInTools: {},
+    providerOptions: { anthropic: anthropicOptions },
+  };
 }
 
 function resolveAzureBackedProvider(args: ResolveProviderArgs): ResolvedProvider {

--- a/src/features/chat-page/chat-services/models/provider.ts
+++ b/src/features/chat-page/chat-services/models/provider.ts
@@ -20,12 +20,19 @@ import { getAzureCognitiveServicesTokenProvider } from "@/features/common/servic
 import { MODEL_CONFIGS, type ChatModel } from "../models";
 
 /** The shape stored under SERVICE_KEYS.aiProvider: a function that maps a
- *  deployment name to a LanguageModelV3. */
-export type AiProviderFn = (deploymentName: string) => LanguageModelV3;
+ *  deployment name to a LanguageModelV3. `api` selects the Azure surface:
+ *  "responses" (default) or "chat" (chat-completions, for models that don't
+ *  support the Responses API). Test fakes that ignore the second arg keep
+ *  working. */
+export type AiProviderFn = (
+  deploymentName: string,
+  api?: "responses" | "chat",
+) => LanguageModelV3;
 
 /**
  * Returns the LanguageModelV3 for the given ChatModel by looking up the
  * deployment name in MODEL_CONFIGS and delegating to the registered aiProvider.
+ * Models with supportsResponsesAPI=false get the chat-completions surface.
  */
 export function resolveAzureModel(modelId: ChatModel): LanguageModelV3 {
   const config = MODEL_CONFIGS[modelId];
@@ -40,7 +47,7 @@ export function resolveAzureModel(modelId: ChatModel): LanguageModelV3 {
     );
   }
   const provider = resolve<AiProviderFn>(SERVICE_KEYS.aiProvider);
-  return provider(deploymentName);
+  return provider(deploymentName, config.supportsResponsesAPI ? "responses" : "chat");
 }
 
 /**
@@ -89,7 +96,8 @@ export function createProductionAzureProvider(): AiProviderFn {
       apiVersion,
       headers: imageGenHeader,
     });
-    return (deploymentName) => azure(deploymentName);
+    return (deploymentName, api) =>
+      api === "chat" ? azure.chat(deploymentName) : azure(deploymentName);
   }
 
   // Azure AD path.
@@ -120,7 +128,8 @@ export function createProductionAzureProvider(): AiProviderFn {
     headers: imageGenHeader,
   });
 
-  return (deploymentName) => azure(deploymentName);
+  return (deploymentName, api) =>
+    api === "chat" ? azure.chat(deploymentName) : azure(deploymentName);
 }
 
 // Register production binding at module init (skipped if already registered,

--- a/src/features/common/services/azure-default-credential.ts
+++ b/src/features/common/services/azure-default-credential.ts
@@ -14,3 +14,14 @@ const COGNITIVE_SERVICES_SCOPE = "https://cognitiveservices.azure.com/.default";
 
 export const getAzureCognitiveServicesTokenProvider = () =>
   getBearerTokenProvider(getAzureDefaultCredential(), COGNITIVE_SERVICES_SCOPE);
+
+/**
+ * Token provider for the Azure AI Foundry data plane
+ * (`*.services.ai.azure.com`). Foundry-served partner models (Anthropic
+ * Claude via the /anthropic Messages API) require this scope — the
+ * cognitive-services scope above is rejected with 401 there.
+ */
+const AI_FOUNDRY_SCOPE = "https://ai.azure.com/.default";
+
+export const getAzureAiFoundryTokenProvider = () =>
+  getBearerTokenProvider(getAzureDefaultCredential(), AI_FOUNDRY_SCOPE);

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -8,6 +8,7 @@
       "name": "azure-open-ai-accelerator",
       "version": "1.2.0",
       "dependencies": {
+        "@ai-sdk/anthropic": "^3.0.81",
         "@ai-sdk/azure": "^3.0.65",
         "@ai-sdk/react": "^3.0.187",
         "@azure/ai-form-recognizer": "^5.1.0",
@@ -106,6 +107,22 @@
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "3.0.81",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.81.tgz",
+      "integrity": "sha512-B1JDd9Ugq9R5AgIaW3674lhGCMMYJcPUxnrZh8fzbGojgg4QvHFRv6eZahGQAUsmGHbcf74G9bdSBDLWQGY2GA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
     },
     "node_modules/@ai-sdk/azure": {
       "version": "3.0.65",

--- a/src/package.json
+++ b/src/package.json
@@ -16,6 +16,7 @@
     "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.81",
     "@ai-sdk/azure": "^3.0.65",
     "@ai-sdk/react": "^3.0.187",
     "@azure/ai-form-recognizer": "^5.1.0",


### PR DESCRIPTION
## Summary
Adds four Azure AI Foundry partner models for multi-model testing alongside the existing gpt-5.* lineup:

| Model | Picker | Transport |
| --- | --- | --- |
| `claude-opus-4-8` | Claude Opus 4.8 | `@ai-sdk/anthropic` → Foundry **Messages API** (`/anthropic/v1`) |
| `claude-sonnet-4-6` | Claude Sonnet 4.6 | same |
| `grok-4.3` | Grok 4.3 | `@ai-sdk/azure` OpenAI-compatible `/openai/v1` Responses API |
| `deepseek-v4-pro` | DeepSeek V4 Pro | same |

## Key points
- **Anthropic seam wired** (was a stub): Claude on Foundry uses the Anthropic-native Messages API at `<resource>.services.ai.azure.com/anthropic`, NOT the OpenAI endpoint. Auth via `AZURE_ANTHROPIC_API_KEY` or Entra ID with the `ai.azure.com` scope (new `getAzureAiFoundryTokenProvider` — the cognitive-services scope is rejected there). Sends `thinking: adaptive` + mapped `effort`; never sends sampling params (Opus 4.8 returns 400 on temperature/top_p/top_k).
- **chat-completions escape hatch**: `AiProviderFn` gains an optional `api` param so `supportsResponsesAPI:false` models use `azure.chat()` (the AI SDK chat-completions surface).
- **DeepSeek** `supportsReasoning:false` — Foundry emits the reasoning item on only ~half of requests.

## Verification
- All four deployments smoke-tested live against dev (`buhler-itp-ai-services-dev-dall-e-3`) with both auth scopes.
- tsc clean for changed files; model/provider unit tests pass (17/17).

## Deployment notes
- Models already deployed on **prod** Foundry (`buhler-itp-ai-services-prod-dall-e-3`): claude-opus-4-8, claude-sonnet-4-6, grok-4.3, DeepSeek-V4-Pro.
- Env vars required per environment (deployment names differ — prod Sonnet is `claude-sonnet-4-6`, dev was `claude-sonnet-4-6-2`):
  `AZURE_OPENAI_API_GROK43_DEPLOYMENT_NAME`, `AZURE_OPENAI_API_DEEPSEEK_V4_DEPLOYMENT_NAME`, `AZURE_ANTHROPIC_OPUS48_DEPLOYMENT_NAME`, `AZURE_ANTHROPIC_SONNET46_DEPLOYMENT_NAME` (+ optional `AZURE_ANTHROPIC_RESOURCE_NAME` / `AZURE_ANTHROPIC_API_KEY`).
- Pricing for Grok/DeepSeek is a placeholder (marked TODO) — verify before relying on cost tracking.

Note: `@ai-sdk/anthropic` added as a dependency.