### PR TITLE
fix(chat): live token-usage in header (no reload); show last input/output

### DIFF
--- a/src/app/(authenticated)/api/chat/route.ts
+++ b/src/app/(authenticated)/api/chat/route.ts
@@ -26,6 +26,7 @@ import { createSandboxUrlTransform } from "@/features/chat-page/chat-services/ch
 import { createImageGenerationStreamRewriter } from "@/features/chat-page/chat-services/chat-api/image-generation-stream-rewriter";
 import { createCodeInterpreterStreamRewriter } from "@/features/chat-page/chat-services/chat-api/code-interpreter-stream-rewriter";
 import { resolveProvider, getFileIdsSignature } from "@/features/chat-page/chat-services/models/provider-seam";
+import { computeRequestUsage, type ChatMessageMetadata } from "@/features/chat-page/chat-services/chat-api/usage-data";
 import {
   UpdateChatTitle,
   UpdateChatThreadCodeInterpreterContainer,
@@ -670,6 +671,23 @@ export async function POST(req: Request) {
     originalMessages: ctx.history,
     generateMessageId: createIdGenerator({ prefix: "msg", size: 16 }),
     onError: (err) => (err instanceof Error ? err.message : String(err)),
+    // Ship the turn's token usage on the assistant message metadata so the
+    // header's live usage display updates every turn (the chat session's
+    // onFinish reads this). Provider-agnostic: the SDK normalises usage to
+    // inputTokens/outputTokens for both Azure (Responses) and Anthropic
+    // (Messages) before it reaches us. Fires on the terminal `finish` part.
+    messageMetadata: ({ part }): ChatMessageMetadata | undefined => {
+      if (part.type !== "finish") return undefined;
+      const u = part.totalUsage;
+      return {
+        usage: computeRequestUsage({
+          inputTokens: u.inputTokens ?? 0,
+          outputTokens: u.outputTokens ?? 0,
+          cachedTokens: u.inputTokenDetails?.cacheReadTokens ?? 0,
+          modelConfig,
+        }),
+      };
+    },
   });
   if (!framedResponse.body) {
     unregisterPublisher(ctx.thread.id);

--- a/src/features/chat-page/chat-services/chat-api/usage-data.test.ts
+++ b/src/features/chat-page/chat-services/chat-api/usage-data.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { computeRequestUsage } from "./usage-data";
+
+const modelConfig = {
+  id: "gpt-5.5",
+  pricing: { inputPerMillion: 5, outputPerMillion: 30, cachedInputPerMillion: 0.5 },
+  contextWindow: 1_000_000,
+} as const;
+
+describe("computeRequestUsage", () => {
+  it("totals tokens and bills cached input at the cached rate", () => {
+    const u = computeRequestUsage({
+      inputTokens: 1000,
+      outputTokens: 200,
+      cachedTokens: 400,
+      modelConfig,
+    });
+    expect(u.totalTokens).toBe(1200);
+    // (600/1e6)*5 + (400/1e6)*0.5 + (200/1e6)*30 = 0.003 + 0.0002 + 0.006
+    expect(u.costUsd).toBeCloseTo(0.0092, 6);
+    expect(u.model).toBe("gpt-5.5");
+  });
+
+  it("computes context usage percent against the model window", () => {
+    const u = computeRequestUsage({
+      inputTokens: 250_000,
+      outputTokens: 0,
+      cachedTokens: 0,
+      modelConfig,
+    });
+    expect(u.contextWindowSize).toBe(1_000_000);
+    expect(u.contextUsagePercent).toBeCloseTo(25, 6);
+  });
+
+  it("never bills negative non-cached input when cached exceeds input", () => {
+    const u = computeRequestUsage({
+      inputTokens: 100,
+      outputTokens: 0,
+      cachedTokens: 500,
+      modelConfig,
+    });
+    // nonCachedInput clamps to 0; cost is just the cached portion.
+    expect(u.costUsd).toBeCloseTo((500 / 1_000_000) * 0.5, 9);
+  });
+
+  it("yields zero cost and percent when pricing/window are absent", () => {
+    const u = computeRequestUsage({
+      inputTokens: 100,
+      outputTokens: 50,
+      cachedTokens: 0,
+      modelConfig: { id: "x", pricing: undefined as never, contextWindow: 0 },
+    });
+    expect(u.costUsd).toBe(0);
+    expect(u.contextUsagePercent).toBe(0);
+    expect(u.totalTokens).toBe(150);
+  });
+});

--- a/src/features/chat-page/chat-services/chat-api/usage-data.ts
+++ b/src/features/chat-page/chat-services/chat-api/usage-data.ts
@@ -1,0 +1,84 @@
+/**
+ * usage-data.ts
+ *
+ * Shared, side-effect-free computation of the per-request token-usage block
+ * the chat header displays (token count, cost estimate, context-window %).
+ *
+ * Why this exists: the AI SDK v6 migration left the live usage wiring
+ * dangling. The store action `setUsageData` was never called on the live
+ * path, so the header's `lastUsageData` only ever reflected the value seeded
+ * at page load — total tokens updated only after a reload, and per-request
+ * input/output always showed 0. The route now ships this block to the client
+ * via `toUIMessageStreamResponse({ messageMetadata })` and the chat session's
+ * `onFinish` feeds it into the store, so the header updates every turn.
+ *
+ * The THREAD running totals (threadTotalTokens / threadTotalCostUsd) are NOT
+ * computed here: the server-side Cosmos read-modify-write that owns them runs
+ * in a different path (persist-assistant). The client merges this per-request
+ * block onto the totals it already holds; a reload reconciles from the
+ * persisted thread usage. Keeping this pure means it's identical across the
+ * Azure (Responses) and Anthropic (Messages) providers — usage is normalised
+ * to inputTokens/outputTokens by the SDK before it reaches us.
+ */
+import type { ModelConfig } from "../models";
+
+/** Per-request usage block carried on assistant-message metadata. */
+export interface RequestUsageMetadata {
+  inputTokens: number;
+  outputTokens: number;
+  cachedTokens: number;
+  totalTokens: number;
+  costUsd: number;
+  contextWindowSize: number;
+  contextUsagePercent: number;
+  model: string;
+}
+
+/** Metadata attached to streamed assistant messages. */
+export interface ChatMessageMetadata {
+  usage?: RequestUsageMetadata;
+}
+
+export interface ComputeRequestUsageArgs {
+  inputTokens: number;
+  outputTokens: number;
+  cachedTokens: number;
+  modelConfig: Pick<ModelConfig, "id" | "pricing" | "contextWindow">;
+}
+
+/**
+ * Compute the per-request usage block from raw token counts. Cost mirrors
+ * persist-assistant exactly: cached input is billed at the cached rate, the
+ * remaining input at the standard rate, output at the output rate.
+ */
+export function computeRequestUsage({
+  inputTokens,
+  outputTokens,
+  cachedTokens,
+  modelConfig,
+}: ComputeRequestUsageArgs): RequestUsageMetadata {
+  const pricing = modelConfig.pricing;
+  let costUsd = 0;
+  if (pricing) {
+    const nonCachedInput = Math.max(inputTokens - cachedTokens, 0);
+    costUsd =
+      (nonCachedInput / 1_000_000) * pricing.inputPerMillion +
+      (cachedTokens / 1_000_000) * pricing.cachedInputPerMillion +
+      (outputTokens / 1_000_000) * pricing.outputPerMillion;
+  }
+
+  const contextWindowSize = modelConfig.contextWindow ?? 0;
+  const contextUsagePercent =
+    contextWindowSize > 0 ? (inputTokens / contextWindowSize) * 100 : 0;
+
+  return {
+    inputTokens,
+    outputTokens,
+    cachedTokens,
+    totalTokens: inputTokens + outputTokens,
+    costUsd,
+    contextWindowSize,
+    contextUsagePercent,
+    model: modelConfig.id,
+  };
+}

--- a/src/features/chat-page/chat-services/chat-thread-service.ts
+++ b/src/features/chat-page/chat-services/chat-thread-service.ts
@@ -644,6 +644,9 @@ export const UpdateChatThreadUsage = async (
         totalCachedTokens: existing.totalCachedTokens + cachedTokens,
         totalCostUsd: existing.totalCostUsd + costUsd,
         lastUpdated: new Date().toISOString(),
+        lastInputTokens: inputTokens,
+        lastOutputTokens: outputTokens,
+        lastCachedTokens: cachedTokens,
       };
       return await UpsertChatThread(chatThread);
     }

--- a/src/features/chat-page/chat-services/models.ts
+++ b/src/features/chat-page/chat-services/models.ts
@@ -241,6 +241,12 @@ export interface ThreadUsage {
   totalCachedTokens: number;
   totalCostUsd: number;
   lastUpdated: string;
+  // Most-recent turn's token counts. Persisted so a reloaded thread can show
+  // the same "Last input/output" the header showed live, instead of 0.
+  // Optional for backward compatibility with rows written before this existed.
+  lastInputTokens?: number;
+  lastOutputTokens?: number;
+  lastCachedTokens?: number;
 }
 
 export interface DefaultTools {

--- a/src/features/chat-page/chat-store-context.tsx
+++ b/src/features/chat-page/chat-store-context.tsx
@@ -36,6 +36,7 @@ import {
 } from "./chat-store-factory";
 import { setActiveChatStore } from "./active-chat-store";
 import type { ChatModel, ChatThreadModel, ReasoningEffort } from "./chat-services/models";
+import type { ChatMessageMetadata } from "./chat-services/chat-api/usage-data";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -283,6 +284,22 @@ export function ChatStoreProvider({
     // while a stream is still in flight). The server replies 204 when
     // there's nothing to resume, so this is cheap-and-safe to leave on.
     resume: true,
+    // Live token-usage: the route attaches the turn's usage to the assistant
+    // message metadata (see toUIMessageStreamResponse messageMetadata). Feed
+    // it into the store so the header updates every turn without a reload.
+    // Thread running totals are accumulated client-side here (the per-request
+    // block carries only this turn); a reload reconciles from persisted usage.
+    onFinish: ({ message }) => {
+      const usage = (message.metadata as ChatMessageMetadata | undefined)?.usage;
+      if (!usage) return;
+      const s = store.getState();
+      const prev = s.lastUsageData;
+      s.setUsageData({
+        ...usage,
+        threadTotalTokens: (prev?.threadTotalTokens ?? 0) + usage.totalTokens,
+        threadTotalCostUsd: (prev?.threadTotalCostUsd ?? 0) + usage.costUsd,
+      });
+    },
   });
 
   /**

--- a/src/features/chat-page/chat-store-factory.ts
+++ b/src/features/chat-page/chat-store-factory.ts
@@ -102,20 +102,27 @@ export function createChatStore(options: CreateChatStoreOptions) {
   const hasCodeInterpreterFiles =
     (chatThread?.attachedFiles ?? []).some((f) => f.type === "code-interpreter");
 
-  // Resolve initial usage data
+  // Resolve initial usage data. Seed the "last turn" input/output from the
+  // persisted per-turn counts (lastInputTokens/…) so a reloaded thread shows
+  // the same values the header showed live, not 0. Older rows without these
+  // fields fall back to 0 (only the thread totals are shown for them).
   let initialUsageData: UsageDataResponse | null = null;
   if (chatThread?.usage) {
+    const u = chatThread.usage;
+    const contextWindowSize = modelCfg?.contextWindow ?? 128000;
+    const lastInput = u.lastInputTokens ?? 0;
+    const lastOutput = u.lastOutputTokens ?? 0;
     initialUsageData = {
-      inputTokens: 0,
-      outputTokens: 0,
-      cachedTokens: 0,
-      totalTokens: 0,
+      inputTokens: lastInput,
+      outputTokens: lastOutput,
+      cachedTokens: u.lastCachedTokens ?? 0,
+      totalTokens: lastInput + lastOutput,
       costUsd: 0,
-      threadTotalCostUsd: chatThread.usage.totalCostUsd,
-      threadTotalTokens:
-        chatThread.usage.totalInputTokens + chatThread.usage.totalOutputTokens,
-      contextWindowSize: modelCfg?.contextWindow ?? 128000,
-      contextUsagePercent: 0,
+      threadTotalCostUsd: u.totalCostUsd,
+      threadTotalTokens: u.totalInputTokens + u.totalOutputTokens,
+      contextWindowSize,
+      contextUsagePercent:
+        contextWindowSize > 0 ? (lastInput / contextWindowSize) * 100 : 0,
       model: initialModel,
     };
   }


### PR DESCRIPTION
## Problem
The token-usage display in the chat header (count, cost, context-window ring) only updated **after a page reload**, and per-request **input/output always showed 0** — only the thread total appeared. Affects every model equally (not provider-specific).

## Root cause
The AI SDK v6 migration left the live usage wiring dangling:
- `setUsageData` (the store action) is **never called** on the live path — the old `type:"usageData"` stream event it consumed is gone.
- The route built `toUIMessageStreamResponse({...})` with **no `messageMetadata`**, so per-turn usage stayed server-side (it is still persisted to Cosmos + emitted to App Insights — the *reporting/metrics* were always fine).
- So the header only ever showed `initialUsageData` (seeded once at load), which hardcoded input/output to 0.

## Fix
- **Server**: emit the turn's usage on the assistant message metadata via `messageMetadata` on the terminal `finish` part, using a new pure `computeRequestUsage()` helper (cost mirrors `persist-assistant`; provider-agnostic — the SDK normalises usage to input/output for both Azure Responses and Anthropic Messages).
- **Client**: `useChat({ onFinish })` reads `message.metadata.usage` → `setUsageData`, accumulating thread running totals client-side. Header now updates **every turn, no reload**.
- **Reload**: persist `lastInput/lastOutput/lastCached` on `ThreadUsage` and seed `initialUsageData` from them, so a reloaded thread shows the last turn's input/output instead of 0 (older rows fall back to 0 gracefully).

## Tests
- New `usage-data` unit suite (cost, context %, cached-clamp, missing pricing).
- Existing token-display / thread-service / persist-assistant / chat-api suites pass (131 tests across the touched areas).