### PR TITLE
Agent publishing to the whole organization, trust levels, usage statistics (v2.4.0)

### DIFF
--- a/src/.env.example
+++ b/src/.env.example
@@ -66,6 +66,11 @@ AZURE_OPENAI_VISION_API_VERSION=2023-12-01-preview
 # Update your admin email addresses - comma separated
 ADMIN_EMAIL_ADDRESS=you@email.com,you2@email.com
 
+# Agent trust management: object ID of the Entra ID group whose members may
+# verify/downgrade/unpublish organization-published agents. May be a
+# security group. Leave empty to disable trust actions for everyone.
+AGENT_VERIFIER_GROUP_ID=
+
 # Identity provider is optional if you are running in development mode locally (npm run dev)
 AUTH_GITHUB_ID=
 AUTH_GITHUB_SECRET=

--- a/src/.env.example
+++ b/src/.env.example
@@ -14,7 +14,9 @@ AZURE_OPENAI_API_EMBEDDINGS_DEPLOYMENT_NAME=text-embedding-3-large
 
 # New v1 API model deployments for Responses API
 AZURE_OPENAI_API_GPT52_DEPLOYMENT_NAME=gpt-5.2
-AZURE_OPENAI_API_GPT53_CHAT_DEPLOYMENT_NAME=gpt-5.3-chat
+AZURE_OPENAI_API_GPT56_SOL_DEPLOYMENT_NAME=gpt-5.6-sol
+AZURE_OPENAI_API_GPT56_TERRA_DEPLOYMENT_NAME=gpt-5.6-terra
+AZURE_OPENAI_API_GPT56_LUNA_DEPLOYMENT_NAME=gpt-5.6-luna
 AZURE_OPENAI_API_GPT55_DEPLOYMENT_NAME=gpt-5.5
 AZURE_OPENAI_API_GPT54_DEPLOYMENT_NAME=gpt-5.4
 AZURE_OPENAI_API_GPT54_MINI_DEPLOYMENT_NAME=gpt-5.4-mini
@@ -27,7 +29,7 @@ AZURE_OPENAI_GPT_IMAGE_DEPLOYMENT_NAME=gpt-image-1
 # Foundry-hosted low-cost models (DeepSeek/Kimi) used as automatic downgrade
 # targets. OpenAI-compatible Chat Completions on the Foundry host's /openai/v1
 # surface; Bearer API-key auth. Leave unset to disable Foundry downgrade
-# targets (gpt-5.4-mini still works as a hardCapEligible Azure fallback).
+# targets (gpt-5.6-luna still works as a hardCapEligible Azure fallback).
 FOUNDRY_OPENAI_BASE_URL=https://<resource>.services.ai.azure.com/openai/v1
 FOUNDRY_API_KEY=
 FOUNDRY_DEEPSEEK_DEPLOYMENT_NAME=DeepSeek-V4-Pro

--- a/src/__tests__/INVENTORY.md
+++ b/src/__tests__/INVENTORY.md
@@ -318,7 +318,7 @@ This is the largest feature folder with complex state management and streaming.
 
 **Models:**
 - `chat-services/models.ts`
-  - `ChatModel` type (gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.3-chat)
+  - `ChatModel` type (gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5, gpt-5.4, gpt-5.4-mini)
   - `MODEL_CONFIGS` record with pricing, context window, reasoning support
   - `ChatThreadModel`, `ChatMessageModel`, `ChatDocumentModel`, `AttachedFileModel`
   - `UserPrompt`, `AzureChatCompletion` response types
@@ -911,7 +911,7 @@ This folder contains shadcn/ui and custom UI primitives. Most are pure presentat
 
 **Completions API** (main LLM)
 - Used in: chat-api-response.ts, openai-responses-stream.ts
-- Models: gpt-5.5, gpt-5.4, gpt-5.4-mini, gpt-5.3-chat
+- Models: gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, gpt-5.5, gpt-5.4, gpt-5.4-mini
 - Test strategy: Mock streaming response
 
 **Embeddings API**

--- a/src/__tests__/e2e-fakes/cosmos.ts
+++ b/src/__tests__/e2e-fakes/cosmos.ts
@@ -60,6 +60,10 @@ class InMemoryContainer {
             this.docs[idx][key] = op.value;
           } else if (op.op === "remove") {
             delete this.docs[idx][key];
+          } else if (op.op === "incr") {
+            const current = this.docs[idx][key];
+            this.docs[idx][key] =
+              (typeof current === "number" ? current : 0) + (op.value ?? 0);
           }
         }
         return { resource: this.docs[idx] };

--- a/src/app/(authenticated)/api/chat/route.ts
+++ b/src/app/(authenticated)/api/chat/route.ts
@@ -472,6 +472,7 @@ export async function POST(req: Request) {
           modelConfig,
           fallbackInfo: fallbackInfo.fellBack ? fallbackInfo : undefined,
           reasoningDurationMs: computeReasoningDurationMs(),
+          personaId: ctx.thread.isTemporary ? undefined : ctx.thread.personaId,
         });
       } catch (err) {
         logError("/api/chat onAbort persist failed", {
@@ -521,6 +522,7 @@ export async function POST(req: Request) {
           fallbackInfo: fallbackInfo.fellBack ? fallbackInfo : undefined,
           streamError: lastStreamError,
           reasoningDurationMs: computeReasoningDurationMs(),
+          personaId: ctx.thread.isTemporary ? undefined : ctx.thread.personaId,
         });
         // Generate a thread title from the first user message. ctx.history
         // has just the user message we appended in loadThreadContext when
@@ -578,6 +580,9 @@ export async function POST(req: Request) {
             fallbackInfo: fallbackInfo.fellBack ? fallbackInfo : undefined,
             streamError: lastStreamError,
             reasoningDurationMs: computeReasoningDurationMs(),
+            personaId: ctx.thread.isTemporary
+              ? undefined
+              : ctx.thread.personaId,
           });
         } catch (retryErr) {
           logError("/api/chat persistAssistantFromFinishEvent retry failed", {

--- a/src/app/(authenticated)/chat/page.tsx
+++ b/src/app/(authenticated)/chat/page.tsx
@@ -1,5 +1,6 @@
 import { userHashedId } from "@/features/auth-page/helpers";
 import { ChatHome } from "@/features/chat-home-page/chat-home";
+import { GetAllAgentStats } from "@/features/common/services/agent-stats-service";
 import { FindAllNewsArticles } from "@/features/common/services/news-service/news-service";
 import { FindAllExtensionForCurrentUser } from "@/features/extensions-page/extension-services/extension-service";
 import { GetUserFavoriteAgents } from "@/features/persona-page/persona-services/agent-favorite-service";
@@ -7,12 +8,13 @@ import { FindAllPersonaForCurrentUser } from "@/features/persona-page/persona-se
 import { DisplayError } from "@/features/ui/error/display-error";
 
 export default async function Home() {
-  const [personaResponse, extensionResponse, newsResponse, favoriteAgentIds, currentUserId] = await Promise.all([
+  const [personaResponse, extensionResponse, newsResponse, favoriteAgentIds, currentUserId, agentStats] = await Promise.all([
     FindAllPersonaForCurrentUser(),
     FindAllExtensionForCurrentUser(),
     FindAllNewsArticles(),
     GetUserFavoriteAgents(),
     userHashedId(),
+    GetAllAgentStats(),
   ]);
 
   if (personaResponse.status !== "OK") {
@@ -34,6 +36,7 @@ export default async function Home() {
       news={newsResponse.response}
       favoriteAgentIds={favoriteAgentIds}
       currentUserId={currentUserId}
+      agentStats={agentStats}
     />
   );
 }

--- a/src/app/(authenticated)/persona/page.tsx
+++ b/src/app/(authenticated)/persona/page.tsx
@@ -1,18 +1,28 @@
 import { userHashedId } from "@/features/auth-page/helpers";
+import { GetAllAgentStats } from "@/features/common/services/agent-stats-service";
 import { FindAllExtensionForCurrentUser } from "@/features/extensions-page/extension-services/extension-service";
 import { ChatPersonaPage } from "@/features/persona-page/persona-page";
 import { GetUserFavoriteAgents } from "@/features/persona-page/persona-services/agent-favorite-service";
+import { IsAgentVerifier } from "@/features/persona-page/persona-services/agent-trust-service";
 import { FindAllPersonaForCurrentUser } from "@/features/persona-page/persona-services/persona-service";
 import { DisplayError } from "@/features/ui/error/display-error";
 
 export default async function Home() {
-  const [personasResponse, extensionsResponse, favoriteIds, currentUserId] =
-    await Promise.all([
-      FindAllPersonaForCurrentUser(),
-      FindAllExtensionForCurrentUser(),
-      GetUserFavoriteAgents(),
-      userHashedId(),
-    ]);
+  const [
+    personasResponse,
+    extensionsResponse,
+    favoriteIds,
+    currentUserId,
+    agentStats,
+    isVerifier,
+  ] = await Promise.all([
+    FindAllPersonaForCurrentUser(),
+    FindAllExtensionForCurrentUser(),
+    GetUserFavoriteAgents(),
+    userHashedId(),
+    GetAllAgentStats(),
+    IsAgentVerifier(),
+  ]);
   if (personasResponse.status !== "OK") {
     return <DisplayError errors={personasResponse.errors} />;
   }
@@ -25,6 +35,8 @@ export default async function Home() {
       extensions={extensionsResponse.response}
       initialFavoriteIds={favoriteIds}
       currentUserId={currentUserId}
+      agentStats={agentStats}
+      isVerifier={isVerifier}
     />
   );
 }

--- a/src/features/chat-home-page/chat-home.tsx
+++ b/src/features/chat-home-page/chat-home.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { AgentStatsModel } from "@/features/common/services/agent-stats-models";
 import { ExtensionModel } from "@/features/extensions-page/extension-services/models";
 import { AgentList } from "@/features/persona-page/agent-list";
 import { AddNewPersona } from "@/features/persona-page/add-new-persona";
@@ -21,6 +22,7 @@ interface ChatPersonaProps {
   news: NewsArticleModel[];
   favoriteAgentIds: string[];
   currentUserId: string;
+  agentStats?: Record<string, AgentStatsModel>;
 }
 
 const FeedbackButton = ({ feedBackLink }: { feedBackLink: string }) => (
@@ -100,7 +102,7 @@ const ArticlesSection = ({
   </div>
 );
 
-export const ChatHome: FC<ChatPersonaProps> = ({ personas, extensions, news, favoriteAgentIds, currentUserId }) => {
+export const ChatHome: FC<ChatPersonaProps> = ({ personas, extensions, news, favoriteAgentIds, currentUserId, agentStats }) => {
   const [showChangelog, setShowChangelog] = useState<boolean>(false);
 
   return (
@@ -134,6 +136,8 @@ export const ChatHome: FC<ChatPersonaProps> = ({ personas, extensions, news, fav
                 personas={personas}
                 initialFavoriteIds={favoriteAgentIds}
                 currentUserId={currentUserId}
+                agentStats={agentStats}
+                favoritesOnly
               />
             </>
           )}

--- a/src/features/chat-page/__tests__/chat-store-factory.test.ts
+++ b/src/features/chat-page/__tests__/chat-store-factory.test.ts
@@ -68,12 +68,12 @@ describe("createChatStore — isolation", () => {
     storeA.subscribe(listenerA);
     storeB.subscribe(listenerB);
 
-    storeA.getState().setSelectedModel("gpt-5.3-chat");
+    storeA.getState().setSelectedModel("gpt-5.4");
 
     expect(listenerA).toHaveBeenCalledOnce();
     expect(listenerB).not.toHaveBeenCalled();
-    expect(storeA.getState().selectedModel).toBe("gpt-5.3-chat");
-    expect(storeB.getState().selectedModel).not.toBe("gpt-5.3-chat");
+    expect(storeA.getState().selectedModel).toBe("gpt-5.4");
+    expect(storeB.getState().selectedModel).not.toBe("gpt-5.4");
   });
 
   // Tool-call-history restoration was deleted with the dead Zustand subsystem

--- a/src/features/chat-page/chat-services/chat-api/model-selection.ts
+++ b/src/features/chat-page/chat-services/chat-api/model-selection.ts
@@ -149,7 +149,10 @@ export async function resolveModelAndLimits(
           reason: "cap",
           originalModel: selectedModel,
           fallbackModel: target,
-          message: `${budget.window === "weekly" ? "Weekly" : "Daily"} cost budget reached. Using ${targetConfig.name} until it resets.`,
+          message:
+            budget.window === "weekly"
+              ? `Rolling 7-day cost budget reached. Using ${targetConfig.name} until your usage from the last 7 days drops below the cap.`
+              : `Daily cost budget reached. Using ${targetConfig.name} until it resets.`,
           limitType: "cost",
           currentUsage: budget.currentUsd ?? 0,
           limit: budget.limitUsd ?? 0,

--- a/src/features/chat-page/chat-services/chat-api/persist-assistant.ts
+++ b/src/features/chat-page/chat-services/chat-api/persist-assistant.ts
@@ -28,6 +28,7 @@ import type {
 import { createIdGenerator } from "ai";
 import { userHashedId } from "@/features/auth-page/helpers";
 import { logError, logInfo, logWarn } from "@/features/common/services/logger";
+import { RecordAgentInteraction } from "@/features/common/services/agent-stats-service";
 import { IncrementUsage } from "@/features/common/services/usage-service";
 import {
   reportPromptTokens,
@@ -148,6 +149,8 @@ export interface PersistPayload {
   };
   /** Token usage from the top-level streamText finish callback */
   usage: UsagePayload;
+  /** Agent (persona) the thread was started from — attributes per-agent stats. */
+  personaId?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -173,6 +176,7 @@ export async function persistThread({
   messages,
   modelConfig,
   usage,
+  personaId,
 }: PersistPayload): Promise<void> {
   const userId = await userHashedId();
 
@@ -336,6 +340,23 @@ export async function persistThread({
     })
   );
 
+  // Per-agent usage counters (atomic Cosmos Patch increments on the
+  // agent-stats doc). Only threads started from an agent carry a personaId.
+  // Note: aborted turns arrive here with zero usage and still count as one
+  // interaction — accepted, the user did see a partial answer.
+  if (personaId) {
+    RecordAgentInteraction(personaId, {
+      inputTokens,
+      outputTokens,
+      cachedTokens,
+    }).catch((err: unknown) =>
+      logError("Failed to record agent interaction", {
+        personaId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    );
+  }
+
   // Emit App Insights custom metrics (OpenTelemetry) consumed by the
   // "Bühler GPT Usage" monitoring workbook. These were dropped when the
   // legacy orchestrator stack was removed (commit 8f818d6); the streamText
@@ -447,6 +468,8 @@ export interface PersistAssistantFromFinishParams<TOOLS extends ToolSet> {
    * hidden behind boilerplate.
    */
   streamError?: { message: string; name?: string };
+  /** Agent (persona) the thread was started from — attributes per-agent stats. */
+  personaId?: string;
 }
 
 /**
@@ -463,6 +486,7 @@ export async function persistAssistantFromFinishEvent<TOOLS extends ToolSet>({
   messageId,
   streamError,
   reasoningDurationMs,
+  personaId,
 }: PersistAssistantFromFinishParams<TOOLS>): Promise<void> {
   // Detect an empty finish — Azure content-filter trips, aborted streams
   // before any output, or a model error that resolves without text/tools.
@@ -582,5 +606,6 @@ export async function persistAssistantFromFinishEvent<TOOLS extends ToolSet>({
       outputTokens: usageDetails.outputTokens ?? 0,
       cachedTokens,
     },
+    personaId,
   });
 }

--- a/src/features/chat-page/chat-services/models.ts
+++ b/src/features/chat-page/chat-services/models.ts
@@ -5,7 +5,7 @@ import {
 } from "@/features/common/services/openai";
 import { logError } from "@/features/common/services/logger";
 
-export const DEFAULT_MODEL: ChatModel = "gpt-5.5";
+export const DEFAULT_MODEL: ChatModel = "gpt-5.6-sol";
 
 export const CHAT_DOCUMENT_ATTRIBUTE = "CHAT_DOCUMENT";
 export const CHAT_THREAD_ATTRIBUTE = "CHAT_THREAD";
@@ -13,10 +13,12 @@ export const MESSAGE_ATTRIBUTE = "CHAT_MESSAGE";
 export const CHAT_CITATION_ATTRIBUTE = "CHAT_CITATION";
 
 export type ChatModel =
+  | "gpt-5.6-sol"
+  | "gpt-5.6-terra"
+  | "gpt-5.6-luna"
   | "gpt-5.5"
   | "gpt-5.4"
   | "gpt-5.4-mini"
-  | "gpt-5.3-chat"
   // Foundry-hosted (OpenAI-compatible) models. Served via the "foundry"
   // provider seam, not Azure Responses. DeepSeek/Kimi double as downgrade
   // targets; Grok is a selectable option.
@@ -96,6 +98,54 @@ export interface ModelConfig {
 }
 
 export const MODEL_CONFIGS: Record<ChatModel, ModelConfig> = {
+  // ── GPT-5.6 family (2026-07-09) ─────────────────────────────────────────
+  // Pricing mirrors the equivalent GPT-5.5-era tier as a placeholder — Azure's
+  // model catalog doesn't expose $/token pricing (cost field is null for every
+  // model, including gpt-5.5 below). Confirm against the real Bühler contract.
+  "gpt-5.6-sol": {
+    id: "gpt-5.6-sol",
+    name: "GPT-5.6 Sol",
+    description: "Flagship GPT-5.6 model with state-of-the-art capabilities",
+    getInstance: () => OpenAIV1ReasoningInstance(),
+    supportsReasoning: true,
+    supportsResponsesAPI: true,
+    supportsImageGeneration: true,
+    deploymentName: process.env.AZURE_OPENAI_API_GPT56_SOL_DEPLOYMENT_NAME,
+    defaultReasoningEffort: "low",
+    pricing: { inputPerMillion: 5, outputPerMillion: 30.00, cachedInputPerMillion: 0.5 },
+    contextWindow: 1050000,
+    fallbackModel: "gpt-5.6-luna",
+    capabilities: ["vision", "imageGen", "webSearch", "code"],
+  },
+  "gpt-5.6-terra": {
+    id: "gpt-5.6-terra",
+    name: "GPT-5.6 Terra",
+    description: "Balanced GPT-5.6 model for everyday advanced tasks",
+    getInstance: () => OpenAIV1ReasoningInstance(),
+    supportsReasoning: true,
+    supportsResponsesAPI: true,
+    supportsImageGeneration: true,
+    deploymentName: process.env.AZURE_OPENAI_API_GPT56_TERRA_DEPLOYMENT_NAME,
+    defaultReasoningEffort: "low",
+    pricing: { inputPerMillion: 2.50, outputPerMillion: 15.00, cachedInputPerMillion: 0.25 },
+    contextWindow: 1050000,
+    fallbackModel: "gpt-5.6-luna",
+    capabilities: ["vision", "imageGen", "webSearch", "code"],
+  },
+  "gpt-5.6-luna": {
+    id: "gpt-5.6-luna",
+    name: "GPT-5.6 Luna",
+    description: "Fast and efficient GPT-5.6 model for everyday tasks",
+    getInstance: () => OpenAIV1Instance(),
+    supportsReasoning: false,
+    supportsResponsesAPI: true,
+    deploymentName: process.env.AZURE_OPENAI_API_GPT56_LUNA_DEPLOYMENT_NAME,
+    defaultReasoningEffort: "medium",
+    pricing: { inputPerMillion: 0.75, outputPerMillion: 4.50, cachedInputPerMillion: 0.075 },
+    contextWindow: 400000,
+    hardCapEligible: true,
+    capabilities: ["vision", "webSearch", "code"],
+  },
   "gpt-5.5": {
     id: "gpt-5.5",
     name: "GPT-5.5",
@@ -108,7 +158,7 @@ export const MODEL_CONFIGS: Record<ChatModel, ModelConfig> = {
     defaultReasoningEffort: "low",
     pricing: { inputPerMillion: 5, outputPerMillion: 30.00, cachedInputPerMillion: 0.5 },
     contextWindow: 1050000,
-    fallbackModel: "gpt-5.4-mini",
+    fallbackModel: "gpt-5.6-luna",
     capabilities: ["vision", "imageGen", "webSearch", "code"],
   },
   "gpt-5.4": {
@@ -123,7 +173,7 @@ export const MODEL_CONFIGS: Record<ChatModel, ModelConfig> = {
     defaultReasoningEffort: "low",
     pricing: { inputPerMillion: 2.50, outputPerMillion: 15.00, cachedInputPerMillion: 0.25 },
     contextWindow: 1050000,
-    fallbackModel: "gpt-5.4-mini",
+    fallbackModel: "gpt-5.6-luna",
     capabilities: ["vision", "imageGen", "webSearch", "code"],
   },
   "gpt-5.4-mini": {
@@ -137,21 +187,6 @@ export const MODEL_CONFIGS: Record<ChatModel, ModelConfig> = {
     defaultReasoningEffort: "medium",
     pricing: { inputPerMillion: 0.75, outputPerMillion: 4.50, cachedInputPerMillion: 0.075 },
     contextWindow: 400000,
-    hardCapEligible: true,
-    capabilities: ["vision", "webSearch", "code"],
-  },
-  "gpt-5.3-chat": {
-    id: "gpt-5.3-chat",
-    name: "GPT-5.3 Chat",
-    description: "GPT-5.3 Chat model optimized for conversational interactions",
-    getInstance: () => OpenAIV1Instance(),
-    supportsReasoning: true,
-    supportsResponsesAPI: true,
-    deploymentName: process.env.AZURE_OPENAI_API_GPT53_CHAT_DEPLOYMENT_NAME,
-    defaultReasoningEffort: "medium",
-    pricing: { inputPerMillion: 1.75, outputPerMillion: 14.00, cachedInputPerMillion: 0.175 },
-    contextWindow: 128000,
-    fallbackModel: "gpt-5.4-mini",
     capabilities: ["vision", "webSearch", "code"],
   },
   // ── Foundry-hosted low-cost downgrade targets ──────────────────────────

--- a/src/features/chat-page/chat-services/models.ts
+++ b/src/features/chat-page/chat-services/models.ts
@@ -460,6 +460,12 @@ export interface ChatThreadModel {
    * downgrade-config.ts). Absent on threads created before this field existed.
    */
   intent?: ChatIntent;
+  /**
+   * Id of the agent (persona) this thread was started from. Absent on
+   * default/extension/temporary chats and on threads created before this
+   * field existed. Used to attribute per-agent usage statistics.
+   */
+  personaId?: string;
 }
 
 export interface UserPrompt {

--- a/src/features/common/services/__tests__/downgrade-config.test.ts
+++ b/src/features/common/services/__tests__/downgrade-config.test.ts
@@ -10,7 +10,7 @@ import { MODEL_CONFIGS } from "@/features/chat-page/chat-services/models";
 
 // Models we toggle deployment names on during tests.
 const FOUNDRY = ["DeepSeek-V4-Pro", "Kimi-K2.6"] as const;
-const MINI = "gpt-5.4-mini" as const;
+const LUNA = "gpt-5.6-luna" as const;
 
 const savedDeploy: Record<string, string | undefined> = {};
 const ENV_KEYS = [
@@ -23,13 +23,13 @@ const ENV_KEYS = [
 const savedEnv: Record<string, string | undefined> = {};
 
 beforeEach(() => {
-  for (const id of [...FOUNDRY, MINI]) {
+  for (const id of [...FOUNDRY, LUNA]) {
     savedDeploy[id] = MODEL_CONFIGS[id].deploymentName;
   }
   // Make all three eligible models "deployed" by default.
   (MODEL_CONFIGS["DeepSeek-V4-Pro"] as any).deploymentName = "DeepSeek-V4-Pro";
   (MODEL_CONFIGS["Kimi-K2.6"] as any).deploymentName = "Kimi-K2.6-1";
-  (MODEL_CONFIGS[MINI] as any).deploymentName = "mini-deploy";
+  (MODEL_CONFIGS[LUNA] as any).deploymentName = "luna-deploy";
   for (const k of ENV_KEYS) {
     savedEnv[k] = process.env[k];
     delete process.env[k];
@@ -37,7 +37,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  for (const id of [...FOUNDRY, MINI]) {
+  for (const id of [...FOUNDRY, LUNA]) {
     (MODEL_CONFIGS[id] as any).deploymentName = savedDeploy[id];
   }
   for (const k of ENV_KEYS) {
@@ -63,21 +63,21 @@ describe("getBudgetConfig", () => {
 
 describe("getDowngradeTargets — hardCapSet", () => {
   it("includes flagged+deployed models, sorted cheapest-first by output price", () => {
-    // output prices: DeepSeek 1.20 < Kimi 2.50 < mini 4.50
+    // output prices: DeepSeek 1.20 < Kimi 2.50 < luna 4.50
     const { hardCapSet } = getDowngradeTargets();
-    expect(hardCapSet).toEqual(["DeepSeek-V4-Pro", "Kimi-K2.6", "gpt-5.4-mini"]);
+    expect(hardCapSet).toEqual(["DeepSeek-V4-Pro", "Kimi-K2.6", "gpt-5.6-luna"]);
   });
 
   it("excludes eligible models that are not deployed", () => {
     (MODEL_CONFIGS["DeepSeek-V4-Pro"] as any).deploymentName = undefined;
     const { hardCapSet } = getDowngradeTargets();
-    expect(hardCapSet).toEqual(["Kimi-K2.6", "gpt-5.4-mini"]);
+    expect(hardCapSet).toEqual(["Kimi-K2.6", "gpt-5.6-luna"]);
   });
 
   it("env allow-list constrains AND reorders the set", () => {
-    process.env.DOWNGRADE_HARDCAP_MODELS = "gpt-5.4-mini,DeepSeek-V4-Pro";
+    process.env.DOWNGRADE_HARDCAP_MODELS = "gpt-5.6-luna,DeepSeek-V4-Pro";
     const { hardCapSet } = getDowngradeTargets();
-    expect(hardCapSet).toEqual(["gpt-5.4-mini", "DeepSeek-V4-Pro"]);
+    expect(hardCapSet).toEqual(["gpt-5.6-luna", "DeepSeek-V4-Pro"]);
   });
 
   it("drops unknown / ineligible ids from the allow-list", () => {

--- a/src/features/common/services/agent-stats-models.ts
+++ b/src/features/common/services/agent-stats-models.ts
@@ -1,0 +1,50 @@
+export const AGENT_STATS_ATTRIBUTE = "AGENT_STATS";
+
+// Sentinel partition-key value (/userId) for all agent-stats docs: the
+// chat-turn hook only knows the personaId (an owner lookup would cost a
+// cross-partition read per turn), and readers can fetch every stats doc
+// with a single-partition query. Write volume is far below hot-partition
+// territory.
+export const AGENT_STATS_PARTITION = "AGENT_STATS";
+
+export const agentStatsDocId = (personaId: string): string =>
+  `AGENT_STATS_${personaId}`;
+
+// Global, atomically-incremented usage counters per agent — intentionally
+// totals only, no time series.
+export interface AgentStatsModel {
+  id: string; // AGENT_STATS_${personaId}
+  userId: typeof AGENT_STATS_PARTITION;
+  type: typeof AGENT_STATS_ATTRIBUTE;
+  personaId: string;
+  chatCount: number; // threads started from this agent
+  messageCount: number; // assistant turns (interactions)
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalCachedTokens: number;
+  lastUsedAt: string; // ISO timestamp
+}
+
+export const emptyAgentStats = (personaId: string): AgentStatsModel => ({
+  id: agentStatsDocId(personaId),
+  userId: AGENT_STATS_PARTITION,
+  type: AGENT_STATS_ATTRIBUTE,
+  personaId,
+  chatCount: 0,
+  messageCount: 0,
+  totalInputTokens: 0,
+  totalOutputTokens: 0,
+  totalCachedTokens: 0,
+  lastUsedAt: new Date().toISOString(),
+});
+
+// Compact display formatting for counters (e.g. 1234 -> "1.2k").
+export const formatCount = (value: number): string => {
+  if (value >= 1_000_000) {
+    return `${(value / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+  }
+  if (value >= 1_000) {
+    return `${(value / 1_000).toFixed(1).replace(/\.0$/, "")}k`;
+  }
+  return `${value}`;
+};

--- a/src/features/common/services/agent-stats-service.test.ts
+++ b/src/features/common/services/agent-stats-service.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---- Build per-test spies that cosmos.ts will use ----
+const mockPatch = vi.fn();
+const mockCreate = vi.fn();
+const mockDelete = vi.fn();
+const mockQueryFetchAll = vi.fn();
+
+let lastItemArgs: [string, string] | null = null;
+let lastQuerySpec: any = null;
+let lastQueryOpts: any = null;
+
+vi.mock("@/features/common/services/cosmos", () => ({
+  HistoryContainer: vi.fn(() => ({
+    item: (docId: string, pk: string) => {
+      lastItemArgs = [docId, pk];
+      return { patch: mockPatch, delete: mockDelete };
+    },
+    items: {
+      create: mockCreate,
+      query: (q: any, opts: any) => {
+        lastQuerySpec = q;
+        lastQueryOpts = opts;
+        return { fetchAll: mockQueryFetchAll };
+      },
+    },
+  })),
+}));
+
+const mockLogError = vi.fn();
+vi.mock("@/features/common/services/logger", () => ({
+  logError: (...args: any[]) => mockLogError(...args),
+}));
+
+const notFound = () => Object.assign(new Error("Not found"), { code: 404 });
+const conflict = () => Object.assign(new Error("Conflict"), { code: 409 });
+
+describe("common.unit.agent-stats — RecordAgentChatStarted", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    lastItemArgs = null;
+  });
+
+  it("agent-stats.001: patches chatCount incr + lastUsedAt set on the sentinel partition", async () => {
+    mockPatch.mockResolvedValueOnce({ resource: {} });
+    const { RecordAgentChatStarted } = await import("./agent-stats-service");
+    await RecordAgentChatStarted("persona-1");
+
+    expect(lastItemArgs).toEqual(["AGENT_STATS_persona-1", "AGENT_STATS"]);
+    expect(mockPatch).toHaveBeenCalledTimes(1);
+    const ops = mockPatch.mock.calls[0][0];
+    expect(ops).toEqual([
+      { op: "incr", path: "/chatCount", value: 1 },
+      expect.objectContaining({ op: "set", path: "/lastUsedAt" }),
+    ]);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("agent-stats.002: on patch 404 creates a seed doc pre-populated with this event", async () => {
+    mockPatch.mockRejectedValueOnce(notFound());
+    mockCreate.mockResolvedValueOnce({ resource: {} });
+    const { RecordAgentChatStarted } = await import("./agent-stats-service");
+    await RecordAgentChatStarted("persona-1");
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    const seed = mockCreate.mock.calls[0][0];
+    expect(seed).toMatchObject({
+      id: "AGENT_STATS_persona-1",
+      userId: "AGENT_STATS",
+      type: "AGENT_STATS",
+      personaId: "persona-1",
+      chatCount: 1,
+      messageCount: 0,
+    });
+    // No second patch needed — the seed carries the increment.
+    expect(mockPatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("agent-stats.003: on create 409 (lost race) re-patches", async () => {
+    mockPatch.mockRejectedValueOnce(notFound());
+    mockCreate.mockRejectedValueOnce(conflict());
+    mockPatch.mockResolvedValueOnce({ resource: {} });
+    const { RecordAgentChatStarted } = await import("./agent-stats-service");
+    await RecordAgentChatStarted("persona-1");
+
+    expect(mockPatch).toHaveBeenCalledTimes(2);
+  });
+
+  it("agent-stats.004: never throws — unexpected errors are logged", async () => {
+    mockPatch.mockRejectedValueOnce(
+      Object.assign(new Error("boom"), { code: 500 })
+    );
+    const { RecordAgentChatStarted } = await import("./agent-stats-service");
+    await expect(RecordAgentChatStarted("persona-1")).resolves.toBeUndefined();
+    expect(mockLogError).toHaveBeenCalled();
+  });
+});
+
+describe("common.unit.agent-stats — RecordAgentInteraction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    lastItemArgs = null;
+  });
+
+  it("agent-stats.005: patches message + token increments atomically", async () => {
+    mockPatch.mockResolvedValueOnce({ resource: {} });
+    const { RecordAgentInteraction } = await import("./agent-stats-service");
+    await RecordAgentInteraction("persona-2", {
+      inputTokens: 100,
+      outputTokens: 50,
+      cachedTokens: 25,
+    });
+
+    expect(lastItemArgs).toEqual(["AGENT_STATS_persona-2", "AGENT_STATS"]);
+    const ops = mockPatch.mock.calls[0][0];
+    expect(ops).toEqual([
+      { op: "incr", path: "/messageCount", value: 1 },
+      { op: "incr", path: "/totalInputTokens", value: 100 },
+      { op: "incr", path: "/totalOutputTokens", value: 50 },
+      { op: "incr", path: "/totalCachedTokens", value: 25 },
+      expect.objectContaining({ op: "set", path: "/lastUsedAt" }),
+    ]);
+  });
+
+  it("agent-stats.006: 404 seed carries the interaction's usage", async () => {
+    mockPatch.mockRejectedValueOnce(notFound());
+    mockCreate.mockResolvedValueOnce({ resource: {} });
+    const { RecordAgentInteraction } = await import("./agent-stats-service");
+    await RecordAgentInteraction("persona-2", {
+      inputTokens: 100,
+      outputTokens: 50,
+      cachedTokens: 0,
+    });
+
+    expect(mockCreate.mock.calls[0][0]).toMatchObject({
+      personaId: "persona-2",
+      chatCount: 0,
+      messageCount: 1,
+      totalInputTokens: 100,
+      totalOutputTokens: 50,
+      totalCachedTokens: 0,
+    });
+  });
+});
+
+describe("common.unit.agent-stats — GetAllAgentStats", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    lastQuerySpec = null;
+    lastQueryOpts = null;
+  });
+
+  it("agent-stats.007: single-partition query, returns map keyed by personaId", async () => {
+    mockQueryFetchAll.mockResolvedValueOnce({
+      resources: [
+        { personaId: "a", messageCount: 5 },
+        { personaId: "b", messageCount: 9 },
+      ],
+    });
+    const { GetAllAgentStats } = await import("./agent-stats-service");
+    const result = await GetAllAgentStats();
+
+    expect(lastQueryOpts).toEqual({ partitionKey: "AGENT_STATS" });
+    expect(lastQuerySpec.parameters).toEqual([
+      { name: "@type", value: "AGENT_STATS" },
+      { name: "@pk", value: "AGENT_STATS" },
+    ]);
+    expect(Object.keys(result)).toEqual(["a", "b"]);
+    expect(result["b"].messageCount).toBe(9);
+  });
+
+  it("agent-stats.008: degrades to empty map on query failure", async () => {
+    mockQueryFetchAll.mockRejectedValueOnce(new Error("cosmos down"));
+    const { GetAllAgentStats } = await import("./agent-stats-service");
+    await expect(GetAllAgentStats()).resolves.toEqual({});
+    expect(mockLogError).toHaveBeenCalled();
+  });
+});
+
+describe("common.unit.agent-stats — DeleteAgentStats", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("agent-stats.009: ignores 404, logs other failures", async () => {
+    mockDelete.mockRejectedValueOnce(notFound());
+    const { DeleteAgentStats } = await import("./agent-stats-service");
+    await expect(DeleteAgentStats("gone")).resolves.toBeUndefined();
+    expect(mockLogError).not.toHaveBeenCalled();
+
+    mockDelete.mockRejectedValueOnce(
+      Object.assign(new Error("boom"), { code: 500 })
+    );
+    await expect(DeleteAgentStats("gone")).resolves.toBeUndefined();
+    expect(mockLogError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/common/services/agent-stats-service.ts
+++ b/src/features/common/services/agent-stats-service.ts
@@ -1,0 +1,150 @@
+"use server";
+import "server-only";
+
+import { PatchOperation, SqlQuerySpec } from "@azure/cosmos";
+import {
+  AGENT_STATS_ATTRIBUTE,
+  AGENT_STATS_PARTITION,
+  AgentStatsModel,
+  agentStatsDocId,
+  emptyAgentStats,
+} from "./agent-stats-models";
+import { HistoryContainer } from "./cosmos";
+import { logError } from "./logger";
+
+/**
+ * Atomic counter update for an agent-stats doc via the Cosmos Patch API
+ * (`incr` is applied server-side, so concurrent turns never lose updates —
+ * unlike the read-modify-write upserts used for per-user usage docs).
+ *
+ * Patch first; on 404 create the doc pre-seeded with this event's values
+ * (no second round-trip); if the create races another writer (409), the doc
+ * now exists, so re-patch.
+ */
+const patchWithCreateFallback = async (
+  personaId: string,
+  operations: PatchOperation[],
+  seed: AgentStatsModel
+): Promise<void> => {
+  const container = HistoryContainer();
+  const docId = agentStatsDocId(personaId);
+  try {
+    await container.item(docId, AGENT_STATS_PARTITION).patch(operations);
+  } catch (error: unknown) {
+    if ((error as { code?: number }).code !== 404) throw error;
+    try {
+      await container.items.create<AgentStatsModel>(seed);
+    } catch (createError: unknown) {
+      if ((createError as { code?: number }).code !== 409) throw createError;
+      // Lost the create race — the doc exists now, apply the increments.
+      await container.item(docId, AGENT_STATS_PARTITION).patch(operations);
+    }
+  }
+};
+
+/**
+ * Records that a new chat thread was started from an agent.
+ * Fire-and-forget on the hot path: never throws, only logs.
+ */
+export const RecordAgentChatStarted = async (
+  personaId: string
+): Promise<void> => {
+  const now = new Date().toISOString();
+  try {
+    await patchWithCreateFallback(
+      personaId,
+      [
+        { op: "incr", path: "/chatCount", value: 1 },
+        { op: "set", path: "/lastUsedAt", value: now },
+      ],
+      { ...emptyAgentStats(personaId), chatCount: 1, lastUsedAt: now }
+    );
+  } catch (error) {
+    logError("agent-stats: RecordAgentChatStarted failed", {
+      personaId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+};
+
+/**
+ * Records one completed assistant turn (interaction) and its token usage.
+ * Fire-and-forget on the hot path: never throws, only logs.
+ */
+export const RecordAgentInteraction = async (
+  personaId: string,
+  usage: { inputTokens: number; outputTokens: number; cachedTokens: number }
+): Promise<void> => {
+  const now = new Date().toISOString();
+  try {
+    await patchWithCreateFallback(
+      personaId,
+      // 5 operations — Cosmos allows up to 10 per patch.
+      [
+        { op: "incr", path: "/messageCount", value: 1 },
+        { op: "incr", path: "/totalInputTokens", value: usage.inputTokens },
+        { op: "incr", path: "/totalOutputTokens", value: usage.outputTokens },
+        { op: "incr", path: "/totalCachedTokens", value: usage.cachedTokens },
+        { op: "set", path: "/lastUsedAt", value: now },
+      ],
+      {
+        ...emptyAgentStats(personaId),
+        messageCount: 1,
+        totalInputTokens: usage.inputTokens,
+        totalOutputTokens: usage.outputTokens,
+        totalCachedTokens: usage.cachedTokens,
+        lastUsedAt: now,
+      }
+    );
+  } catch (error) {
+    logError("agent-stats: RecordAgentInteraction failed", {
+      personaId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+};
+
+/**
+ * All agent stats keyed by personaId — a single-partition query (sentinel
+ * partition), never a container scan. Errors degrade to an empty map so
+ * pages render without stats rather than failing.
+ */
+export const GetAllAgentStats = async (): Promise<
+  Record<string, AgentStatsModel>
+> => {
+  try {
+    const querySpec: SqlQuerySpec = {
+      query: "SELECT * FROM root r WHERE r.type=@type AND r.userId=@pk",
+      parameters: [
+        { name: "@type", value: AGENT_STATS_ATTRIBUTE },
+        { name: "@pk", value: AGENT_STATS_PARTITION },
+      ],
+    };
+    const { resources } = await HistoryContainer()
+      .items.query<AgentStatsModel>(querySpec, {
+        partitionKey: AGENT_STATS_PARTITION,
+      })
+      .fetchAll();
+    return Object.fromEntries(resources.map((s) => [s.personaId, s]));
+  } catch (error) {
+    logError("agent-stats: GetAllAgentStats failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return {};
+  }
+};
+
+/** Best-effort cleanup when an agent is deleted; a missing doc is fine. */
+export const DeleteAgentStats = async (personaId: string): Promise<void> => {
+  try {
+    await HistoryContainer()
+      .item(agentStatsDocId(personaId), AGENT_STATS_PARTITION)
+      .delete();
+  } catch (error: unknown) {
+    if ((error as { code?: number }).code === 404) return;
+    logError("agent-stats: DeleteAgentStats failed", {
+      personaId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+};

--- a/src/features/common/services/usage-service.ts
+++ b/src/features/common/services/usage-service.ts
@@ -109,7 +109,9 @@ export async function GetWeeklyUsage(
   const uid = userId || (await userHashedId());
   const today = new Date();
   const weekAgo = new Date(today);
-  weekAgo.setDate(weekAgo.getDate() - 7);
+  // -6, not -7: with an inclusive >= comparison below, this yields exactly a
+  // 7-calendar-day window (today and the preceding 6 days).
+  weekAgo.setDate(weekAgo.getDate() - 6);
   const weekAgoStr = weekAgo.toISOString().split("T")[0];
 
   try {

--- a/src/features/main-menu/user-usage.tsx
+++ b/src/features/main-menu/user-usage.tsx
@@ -49,22 +49,6 @@ function getDailyResetLabel(): string {
   return `${minutes}m`;
 }
 
-function getWeeklyResetLabel(): string {
-  const now = new Date();
-  const friday = new Date(now);
-  const dayOfWeek = now.getDay();
-  let daysUntilFri = (5 - dayOfWeek + 7) % 7;
-  if (daysUntilFri === 0 && now.getHours() >= 17) daysUntilFri = 7;
-  friday.setDate(now.getDate() + daysUntilFri);
-  friday.setHours(17, 0, 0, 0);
-  const diffMs = friday.getTime() - now.getTime();
-  const days = Math.floor(diffMs / 86_400_000);
-  const hours = Math.floor((diffMs % 86_400_000) / 3_600_000);
-  if (days > 1) return `Fri 17:00 (${days}d)`;
-  if (days === 1) return `1d ${hours}h`;
-  return `${hours}h`;
-}
-
 /**
  * Usage-toward-budget bar. Hidden when no limit is configured (limit <= 0).
  * Green under 80%, amber 80–99%, red once the cap is hit (the point at which
@@ -159,8 +143,8 @@ export const UserUsage = () => {
             <DropdownMenuSeparator />
             <DropdownMenuLabel className="font-normal py-2">
               <div className="flex items-baseline justify-between mb-2">
-                <p className="text-sm font-semibold tracking-tight">This Week</p>
-                <span className="text-[10px] text-muted-foreground/70">resets {getWeeklyResetLabel()}</span>
+                <p className="text-sm font-semibold tracking-tight">Last 7 Days</p>
+                <span className="text-[10px] text-muted-foreground/70">rolling 7-day sum</span>
               </div>
               <div className="flex gap-4 text-xs">
                 <div>

--- a/src/features/persona-page/add-new-persona.test.tsx
+++ b/src/features/persona-page/add-new-persona.test.tsx
@@ -52,7 +52,13 @@ vi.mock("./persona-documents/code-interpreter-documents", () => ({
 }));
 
 vi.mock("./persona-access-group/persona-access-group", () => ({
-  PersonaAccessGroup: () => <div data-testid="persona-access-group" />,
+  PersonaAccessGroup: (props: any) => (
+    <div
+      data-testid="persona-access-group"
+      data-published={String(props.initialIsPublished)}
+      data-trust={props.trustLevel ?? ""}
+    />
+  ),
 }));
 
 vi.mock("../chat-page/chat-services/models", async () => {
@@ -94,15 +100,38 @@ describe("persona-page.unit.components.001/002 — AddNewPersona", () => {
     expect(screen.getByPlaceholderText(/short description/i)).toBeInTheDocument();
   });
 
-  it("does NOT show Publish switch for non-admin", () => {
+  it("passes publish state into the access section (unpublished, no trust)", () => {
     render(<AddNewPersona extensions={[]} personas={[]} />);
-    expect(screen.queryByText("Publish")).not.toBeInTheDocument();
+    const access = screen.getByTestId("persona-access-group");
+    expect(access.dataset.published).toBe("false");
+    expect(access.dataset.trust).toBe("");
   });
 
-  it("shows Publish switch for admin", () => {
-    mockUseSession.mockReturnValue({ data: { user: { isAdmin: true } } });
+  it("passes the legacy-verified trust level when published without trustLevel", () => {
+    (usePersonaState as any).mockReturnValue({
+      ...mockPersonaState,
+      persona: { ...mockPersonaState.persona, isPublished: true },
+    });
     render(<AddNewPersona extensions={[]} personas={[]} />);
-    expect(screen.getByText("Publish")).toBeInTheDocument();
+    const access = screen.getByTestId("persona-access-group");
+    // Published without a stored trustLevel = legacy admin publish → verified.
+    expect(access.dataset.published).toBe("true");
+    expect(access.dataset.trust).toBe("verified");
+  });
+
+  it("passes the community trust level for community-published agents", () => {
+    (usePersonaState as any).mockReturnValue({
+      ...mockPersonaState,
+      persona: {
+        ...mockPersonaState.persona,
+        isPublished: true,
+        trustLevel: "community",
+      },
+    });
+    render(<AddNewPersona extensions={[]} personas={[]} />);
+    expect(screen.getByTestId("persona-access-group").dataset.trust).toBe(
+      "community"
+    );
   });
 
   it("does not render the sheet when isOpened is false", () => {

--- a/src/features/persona-page/add-new-persona.tsx
+++ b/src/features/persona-page/add-new-persona.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useSession } from "next-auth/react";
 import { FC, startTransition, useState, useEffect } from "react";
 import { ServerActionResponse } from "../common/server-action-response";
 import { Button } from "../ui/button";
@@ -15,7 +14,6 @@ import {
   SheetHeader,
   SheetTitle,
 } from "../ui/sheet";
-import { Switch } from "../ui/switch";
 import { Textarea } from "../ui/textarea";
 import {
   Select,
@@ -31,14 +29,18 @@ import {
 } from "./persona-store";
 import { ExtensionDetail } from "../chat-page/chat-header/extension-detail";
 import { ExtensionModel } from "../extensions-page/extension-services/models";
-import { PersonaModel, DefaultTools } from "./persona-services/models";
+import {
+  PersonaModel,
+  DefaultTools,
+  effectiveTrustLevel,
+} from "./persona-services/models";
 import { PersonaDocuments } from "./persona-documents/persona-documents";
 import { CodeInterpreterDocuments } from "./persona-documents/code-interpreter-documents";
 import { PersonaAccessGroup } from "./persona-access-group/persona-access-group";
 import { TooltipProvider } from "@radix-ui/react-tooltip";
 import { useResetableActionState } from "../common/hooks/useResetableActionState";
 import { AdvancedLoadingIndicator } from "../ui/advanced-loading-indicator";
-import { MODEL_CONFIGS, getAvailableModels, ChatModel, ModelConfig } from "../chat-page/chat-services/models";
+import { MODEL_CONFIGS, getAvailableModels, ModelConfig } from "../chat-page/chat-services/models";
 
 interface Props {
   extensions: Array<ExtensionModel>;
@@ -54,8 +56,6 @@ export const AddNewPersona: FC<Props> = (props) => {
     AddOrUpdatePersona,
     initialState
   );
-
-  const { data } = useSession();
 
   const [selectedModel, setSelectedModel] = useState<string>(
     persona.selectedModel || "__default__"
@@ -99,19 +99,6 @@ export const AddNewPersona: FC<Props> = (props) => {
   const availableSubAgents = props.personas.filter(
     (p) => p.id !== persona.id
   );
-
-  const PublicSwitch = () => {
-    if (data === undefined || data === null) return null;
-
-    if (data?.user?.isAdmin) {
-      return (
-        <div className="flex items-center space-x-2">
-          <Switch name="isPublished" defaultChecked={persona.isPublished} />
-          <Label htmlFor="description">Publish</Label>
-        </div>
-      );
-    }
-  };
 
   return (
     <Sheet
@@ -316,6 +303,8 @@ export const AddNewPersona: FC<Props> = (props) => {
                 )}
                 <PersonaAccessGroup
                   initialSelectedGroup={persona.accessGroup?.id || null}
+                  initialIsPublished={persona.isPublished}
+                  trustLevel={effectiveTrustLevel(persona)}
                 />
                 <PersonaDocuments
                   initialPersonaDocumentIds={persona.personaDocumentIds || []}
@@ -325,8 +314,8 @@ export const AddNewPersona: FC<Props> = (props) => {
                 />
               </div>
             </ScrollArea>
-            <SheetFooter className="py-2 flex sm:justify-between flex-row">
-              <PublicSwitch /> <Submit isLoading={isLoading} />
+            <SheetFooter className="py-2 flex justify-end flex-row">
+              <Submit isLoading={isLoading} />
             </SheetFooter>
           </form>
         </TooltipProvider>

--- a/src/features/persona-page/agent-list.tsx
+++ b/src/features/persona-page/agent-list.tsx
@@ -1,19 +1,53 @@
 "use client";
 
+import { AgentStatsModel } from "@/features/common/services/agent-stats-models";
+import Link from "next/link";
 import { FC, useMemo, useState, useCallback } from "react";
-import { Search } from "lucide-react";
+import { Search, ShieldCheck, Store, VenetianMask } from "lucide-react";
 import { Input } from "../ui/input";
 import { Button } from "../ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
+import { AgentSortSelect } from "./agent-sort-select";
+import { AgentSortKey, sortAgents } from "./agent-sort";
 import { PersonaCard } from "./persona-card/persona-card";
-import { PersonaModel } from "./persona-services/models";
+import { effectiveTrustLevel, PersonaModel } from "./persona-services/models";
+import { personaStore } from "./persona-store";
 
 const PAGE_SIZE = 12;
+
+const NEW_AGENT_TEMPLATE = {
+  name: "",
+  personaMessage: `Instructions:
+[Describe the instructions e.g. the tone of voice, the way the agent should respond, etc.]
+
+Expertise:
+[Describe the expertise of the agent e.g. Customer service, Marketing copywriter, etc.]
+
+Example:
+[Describe an example of the agent e.g. a Marketing copywriter who can write catchy headlines.]`,
+  description: "",
+  extensionIds: [],
+};
+
+type TrustFilter = "all" | "verified" | "community";
 
 interface AgentListProps {
   personas: PersonaModel[];
   initialFavoriteIds: string[];
   currentUserId: string;
   showContextMenu?: boolean;
+  agentStats?: Record<string, AgentStatsModel>;
+  // Home screen mode: render only the favorites — discovery of other agents
+  // happens in the marketplace / on the agents page.
+  favoritesOnly?: boolean;
+  // Current user may verify/downgrade/unpublish published agents.
+  isVerifier?: boolean;
 }
 
 export const AgentList: FC<AgentListProps> = ({
@@ -21,8 +55,13 @@ export const AgentList: FC<AgentListProps> = ({
   initialFavoriteIds,
   currentUserId,
   showContextMenu = false,
+  agentStats,
+  favoritesOnly = false,
+  isVerifier = false,
 }) => {
   const [searchQuery, setSearchQuery] = useState("");
+  const [sortKey, setSortKey] = useState<AgentSortKey>("mostUsed");
+  const [trustFilter, setTrustFilter] = useState<TrustFilter>("all");
   const [currentPage, setCurrentPage] = useState(1);
   const [favoriteIds, setFavoriteIds] = useState<Set<string>>(
     () => new Set(initialFavoriteIds)
@@ -41,14 +80,20 @@ export const AgentList: FC<AgentListProps> = ({
   }, []);
 
   const filteredPersonas = useMemo(() => {
-    if (!searchQuery.trim()) return personas;
+    let result = sortAgents(personas, sortKey, agentStats);
+    if (trustFilter !== "all") {
+      result = result.filter(
+        (p) => effectiveTrustLevel(p) === trustFilter
+      );
+    }
+    if (!searchQuery.trim()) return result;
     const query = searchQuery.toLowerCase();
-    return personas.filter(
+    return result.filter(
       (p) =>
         p.name.toLowerCase().includes(query) ||
         p.description.toLowerCase().includes(query)
     );
-  }, [personas, searchQuery]);
+  }, [personas, searchQuery, sortKey, trustFilter, agentStats]);
 
   const favoritePersonas = useMemo(
     () => filteredPersonas.filter((p) => favoriteIds.has(p.id)),
@@ -60,9 +105,12 @@ export const AgentList: FC<AgentListProps> = ({
     [filteredPersonas, favoriteIds]
   );
 
-  const totalPages = Math.max(1, Math.ceil(allPersonas.length / PAGE_SIZE));
+  // On the home screen pagination applies to the favorites themselves;
+  // otherwise favorites render in full and the "All Agents" grid paginates.
+  const paginatedSource = favoritesOnly ? favoritePersonas : allPersonas;
+  const totalPages = Math.max(1, Math.ceil(paginatedSource.length / PAGE_SIZE));
   const safePage = Math.min(currentPage, totalPages);
-  const paginatedPersonas = allPersonas.slice(
+  const paginatedPersonas = paginatedSource.slice(
     (safePage - 1) * PAGE_SIZE,
     safePage * PAGE_SIZE
   );
@@ -72,85 +120,193 @@ export const AgentList: FC<AgentListProps> = ({
     setCurrentPage(1);
   };
 
+  const handleSortChange = (value: AgentSortKey) => {
+    setSortKey(value);
+    setCurrentPage(1);
+  };
+
+  const pagination = totalPages > 1 && (
+    <div className="flex items-center justify-center gap-4 mt-6">
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={safePage <= 1}
+        onClick={() => setCurrentPage(safePage - 1)}
+      >
+        Previous
+      </Button>
+      <span className="text-sm text-muted-foreground">
+        Page {safePage} of {totalPages}
+      </span>
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={safePage >= totalPages}
+        onClick={() => setCurrentPage(safePage + 1)}
+      >
+        Next
+      </Button>
+    </div>
+  );
+
+  const handleTrustFilterChange = (value: TrustFilter) => {
+    setTrustFilter(value);
+    setCurrentPage(1);
+  };
+
+  const renderCard = (persona: PersonaModel, isFavorited: boolean) => (
+    <PersonaCard
+      persona={persona}
+      key={persona.id}
+      showContextMenu={showContextMenu}
+      showActionMenu={persona.userId === currentUserId}
+      isFavorited={isFavorited}
+      onToggleFavorite={handleToggleFavorite}
+      isVerifier={isVerifier}
+      stats={agentStats?.[persona.id]}
+    />
+  );
+
+  if (favoritesOnly) {
+    return (
+      <div>
+        <div className="flex flex-col sm:flex-row gap-3 mb-6">
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+            <Input
+              type="search"
+              id="agent-search"
+              name="agent-search"
+              placeholder="Search agents by name or description..."
+              className="pl-9"
+              value={searchQuery}
+              onChange={(e) => handleSearchChange(e.target.value)}
+            />
+          </div>
+          <AgentSortSelect value={sortKey} onChange={handleSortChange} />
+          <Button asChild variant="secondary" className="gap-2 shrink-0">
+            <Link href="/agent">
+              <Store className="h-4 w-4" />
+              Browse all agents
+            </Link>
+          </Button>
+        </div>
+
+        <h2 className="text-2xl font-bold mb-3">Favorites</h2>
+        {paginatedPersonas.length > 0 ? (
+          <>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+              {paginatedPersonas.map((persona) => renderCard(persona, true))}
+            </div>
+            {pagination}
+          </>
+        ) : searchQuery ? (
+          <p className="text-muted-foreground">No agents match your search.</p>
+        ) : (
+          <div className="border rounded-md p-8 flex flex-col items-center gap-4 text-center">
+            <p className="text-muted-foreground">
+              You haven&apos;t added any agents yet.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-3">
+              <Button asChild className="gap-2">
+                <Link href="/agent">
+                  <Store className="h-4 w-4" />
+                  Browse all agents
+                </Link>
+              </Button>
+              <Button
+                variant="outline"
+                className="gap-2"
+                onClick={() => personaStore.newPersonaAndOpen(NEW_AGENT_TEMPLATE)}
+              >
+                <VenetianMask className="h-4 w-4" />
+                Create Agent
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
   return (
     <div>
-      <div className="relative mb-6">
-        <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
-        <Input
-          type="search"
-          placeholder="Search agents by name or description..."
-          className="pl-9"
-          value={searchQuery}
-          onChange={(e) => handleSearchChange(e.target.value)}
-        />
+      <div className="flex flex-col sm:flex-row gap-3 mb-6">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+          <Input
+            type="search"
+            id="agent-search"
+            name="agent-search"
+            placeholder="Search agents by name or description..."
+            className="pl-9"
+            value={searchQuery}
+            onChange={(e) => handleSearchChange(e.target.value)}
+          />
+        </div>
+        <Select
+          value={trustFilter}
+          onValueChange={(value) =>
+            handleTrustFilterChange(value as TrustFilter)
+          }
+        >
+          <SelectTrigger
+            className="w-full sm:w-[150px]"
+            aria-label="Filter by trust level"
+          >
+            {/* grouped in a div — the trigger's justify-between would
+                otherwise spread icon and label apart */}
+            <div className="flex items-center gap-2">
+              <ShieldCheck className="h-4 w-4 text-muted-foreground shrink-0" />
+              <SelectValue placeholder="Trust" />
+            </div>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All agents</SelectItem>
+            <SelectItem value="verified">Verified</SelectItem>
+            <SelectItem value="community">Community</SelectItem>
+          </SelectContent>
+        </Select>
+        <AgentSortSelect value={sortKey} onChange={handleSortChange} />
       </div>
 
       {favoritePersonas.length > 0 && (
         <div className="mb-8">
-          <h2 className="text-lg font-semibold mb-3">Favorites</h2>
+          <h2 className="text-2xl font-bold mb-3">Favorites</h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-            {favoritePersonas.map((persona) => (
-              <PersonaCard
-                persona={persona}
-                key={persona.id}
-                showContextMenu={showContextMenu}
-                showActionMenu={persona.userId === currentUserId}
-                isFavorited
-                onToggleFavorite={handleToggleFavorite}
-              />
-            ))}
+            {favoritePersonas.map((persona) => renderCard(persona, true))}
           </div>
         </div>
       )}
 
       <div>
-        <h2 className="text-lg font-semibold mb-3">
+        <h2 className="text-2xl font-bold mb-3">
           {favoritePersonas.length > 0 ? "All Agents" : "Agents"}
         </h2>
         {paginatedPersonas.length > 0 ? (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-            {paginatedPersonas.map((persona) => (
-              <PersonaCard
-                persona={persona}
-                key={persona.id}
-                showContextMenu={showContextMenu}
-                showActionMenu={persona.userId === currentUserId}
-                isFavorited={false}
-                onToggleFavorite={handleToggleFavorite}
-              />
-            ))}
+            {paginatedPersonas.map((persona) => renderCard(persona, false))}
+          </div>
+        ) : searchQuery || trustFilter !== "all" ? (
+          <div className="flex items-center gap-3">
+            <p className="text-muted-foreground">
+              No agents match your {searchQuery ? "search" : "filter"}.
+            </p>
+            {trustFilter !== "all" && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => handleTrustFilterChange("all")}
+              >
+                Clear filter
+              </Button>
+            )}
           </div>
         ) : (
-          <p className="text-muted-foreground">
-            {searchQuery
-              ? "No agents match your search."
-              : "No agents found."}
-          </p>
+          <p className="text-muted-foreground">No agents found.</p>
         )}
 
-        {totalPages > 1 && (
-          <div className="flex items-center justify-center gap-4 mt-6">
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={safePage <= 1}
-              onClick={() => setCurrentPage(safePage - 1)}
-            >
-              Previous
-            </Button>
-            <span className="text-sm text-muted-foreground">
-              Page {safePage} of {totalPages}
-            </span>
-            <Button
-              variant="outline"
-              size="sm"
-              disabled={safePage >= totalPages}
-              onClick={() => setCurrentPage(safePage + 1)}
-            >
-              Next
-            </Button>
-          </div>
-        )}
+        {pagination}
       </div>
     </div>
   );

--- a/src/features/persona-page/agent-sort-select.tsx
+++ b/src/features/persona-page/agent-sort-select.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { ArrowUpDown } from "lucide-react";
+import { FC } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
+import { AGENT_SORT_OPTIONS, AgentSortKey } from "./agent-sort";
+
+interface AgentSortSelectProps {
+  value: AgentSortKey;
+  onChange: (value: AgentSortKey) => void;
+}
+
+export const AgentSortSelect: FC<AgentSortSelectProps> = ({
+  value,
+  onChange,
+}) => {
+  return (
+    <Select
+      value={value}
+      onValueChange={(next) => onChange(next as AgentSortKey)}
+    >
+      <SelectTrigger
+        className="w-full sm:w-[190px]"
+        aria-label="Sort agents"
+      >
+        {/* div (not span): the trigger's [&>span]:line-clamp-1 would clobber
+            a span wrapper's flex display */}
+        <div className="flex items-center gap-2">
+          <ArrowUpDown className="h-4 w-4 text-muted-foreground shrink-0" />
+          <SelectValue placeholder="Sort by" />
+        </div>
+      </SelectTrigger>
+      <SelectContent>
+        {AGENT_SORT_OPTIONS.map((option) => (
+          <SelectItem key={option.value} value={option.value}>
+            {option.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+};

--- a/src/features/persona-page/agent-sort.ts
+++ b/src/features/persona-page/agent-sort.ts
@@ -1,0 +1,46 @@
+import { AgentStatsModel } from "@/features/common/services/agent-stats-models";
+import { PersonaModel } from "./persona-services/models";
+
+export type AgentSortKey = "mostUsed" | "recentlyUpdated" | "newest" | "name";
+
+export const AGENT_SORT_OPTIONS: Array<{
+  value: AgentSortKey;
+  label: string;
+}> = [
+  { value: "mostUsed", label: "Most used" },
+  { value: "recentlyUpdated", label: "Recently updated" },
+  { value: "newest", label: "Newest" },
+  { value: "name", label: "Name (A-Z)" },
+];
+
+const timestamp = (date?: Date | string): number =>
+  date ? new Date(date).getTime() : 0;
+
+const lastModified = (persona: PersonaModel): number =>
+  timestamp(persona.updatedAt) || timestamp(persona.createdAt);
+
+export const sortAgents = (
+  personas: PersonaModel[],
+  key: AgentSortKey,
+  stats?: Record<string, AgentStatsModel>
+): PersonaModel[] => {
+  return [...personas].sort((a, b) => {
+    switch (key) {
+      case "name":
+        return a.name.localeCompare(b.name);
+      case "newest":
+        return timestamp(b.createdAt) - timestamp(a.createdAt);
+      case "recentlyUpdated":
+        return lastModified(b) - lastModified(a);
+      case "mostUsed": {
+        const statsA = stats?.[a.id];
+        const statsB = stats?.[b.id];
+        return (
+          (statsB?.messageCount ?? 0) - (statsA?.messageCount ?? 0) ||
+          (statsB?.chatCount ?? 0) - (statsA?.chatCount ?? 0) ||
+          lastModified(b) - lastModified(a)
+        );
+      }
+    }
+  });
+};

--- a/src/features/persona-page/persona-access-group/persona-access-group-selector.tsx
+++ b/src/features/persona-page/persona-access-group/persona-access-group-selector.tsx
@@ -20,6 +20,7 @@ import { logoutOnSessionExpired } from "@/features/auth-page/logout-on-session-e
 interface Props {
   onSelectGroup: (group: AccessGroup) => void;
   selectedAccessGroupId: string;
+  disabled?: boolean;
 }
 
 type SelectedAccessGroup = AccessGroup & {
@@ -85,10 +86,11 @@ export const PersonaAccessGroupSelector: FC<Props> = (props) => {
     <>
       <Button
         onClick={() => setOpen(true)}
-        className="p-1 cursor-pointer"
+        className="p-1 cursor-pointer disabled:cursor-not-allowed"
         variant={"ghost"}
         type="button"
         size={"icon"}
+        disabled={props.disabled}
       >
         <Edit size={15} />
       </Button>

--- a/src/features/persona-page/persona-access-group/persona-access-group.test.tsx
+++ b/src/features/persona-page/persona-access-group/persona-access-group.test.tsx
@@ -16,10 +16,15 @@ vi.mock("@/features/auth-page/logout-on-session-expired", () => ({
 }));
 
 vi.mock("./persona-access-group-selector", () => ({
-  PersonaAccessGroupSelector: ({ onSelectGroup, selectedAccessGroupId }: any) => (
+  PersonaAccessGroupSelector: ({
+    onSelectGroup,
+    selectedAccessGroupId,
+    disabled,
+  }: any) => (
     <button
       data-testid="group-selector"
       data-selected={selectedAccessGroupId}
+      disabled={disabled}
       onClick={() =>
         onSelectGroup({ id: "g99", name: "Test Group", description: "tg" })
       }
@@ -31,35 +36,40 @@ vi.mock("./persona-access-group-selector", () => ({
 
 vi.mock("@/features/ui/tooltip", () => ({
   Tooltip: ({ children }: any) => <>{children}</>,
-  TooltipTrigger: ({ children, asChild }: any) => <>{children}</>,
+  TooltipTrigger: ({ children }: any) => <>{children}</>,
   TooltipContent: ({ children }: any) => <div>{children}</div>,
+  TooltipProvider: ({ children }: any) => <>{children}</>,
 }));
 
 import { PersonaAccessGroup } from "./persona-access-group";
+
+const defaultProps = {
+  initialSelectedGroup: null,
+  initialIsPublished: false,
+  trustLevel: null,
+};
 
 describe("persona-page.unit.components.008 — PersonaAccessGroup", () => {
   beforeEach(() => vi.clearAllMocks());
 
   // ── No initial group ──────────────────────────────────────────────────────
 
-  it("renders 'Everyone can view this agent' when no initial group", () => {
-    render(<PersonaAccessGroup initialSelectedGroup={null} />);
-    expect(screen.getByDisplayValue("Everyone can view this agent")).toBeInTheDocument();
+  it("renders 'Only you can access this agent' when no group and unpublished", () => {
+    render(<PersonaAccessGroup {...defaultProps} />);
+    expect(
+      screen.getByDisplayValue("Only you can access this agent")
+    ).toBeInTheDocument();
   });
 
   it("Trash button is disabled when no group selected", () => {
-    render(<PersonaAccessGroup initialSelectedGroup={null} />);
-    // Find the trash button (ghost icon button)
+    render(<PersonaAccessGroup {...defaultProps} />);
     const buttons = screen.getAllByRole("button");
-    // The first icon-button variant is the trash button
     const trashBtn = buttons.find((b) => b.hasAttribute("disabled"));
     expect(trashBtn).toBeDefined();
   });
 
   it("hidden accessGroupId input is empty when no group selected", () => {
-    const { container } = render(
-      <PersonaAccessGroup initialSelectedGroup={null} />
-    );
+    const { container } = render(<PersonaAccessGroup {...defaultProps} />);
     const hidden = container.querySelector<HTMLInputElement>(
       'input[name="accessGroupId"]'
     );
@@ -73,7 +83,9 @@ describe("persona-page.unit.components.008 — PersonaAccessGroup", () => {
       status: "OK",
       response: { id: "g1", name: "Finance", description: "" },
     });
-    render(<PersonaAccessGroup initialSelectedGroup="g1" />);
+    render(
+      <PersonaAccessGroup {...defaultProps} initialSelectedGroup="g1" />
+    );
     await waitFor(() => {
       expect(screen.getByDisplayValue("Finance")).toBeInTheDocument();
     });
@@ -85,10 +97,12 @@ describe("persona-page.unit.components.008 — PersonaAccessGroup", () => {
       status: "ERROR",
       errors: [{ message: "not found" }],
     });
-    render(<PersonaAccessGroup initialSelectedGroup="g-bad" />);
+    render(
+      <PersonaAccessGroup {...defaultProps} initialSelectedGroup="g-bad" />
+    );
     await waitFor(() => {
       expect(
-        screen.getByDisplayValue("Everyone can view this agent")
+        screen.getByDisplayValue("Only you can access this agent")
       ).toBeInTheDocument();
     });
   });
@@ -96,40 +110,74 @@ describe("persona-page.unit.components.008 — PersonaAccessGroup", () => {
   // ── Selecting a group via selector ────────────────────────────────────────
 
   it("shows the newly selected group name after selector fires onSelectGroup", async () => {
-    render(<PersonaAccessGroup initialSelectedGroup={null} />);
+    render(<PersonaAccessGroup {...defaultProps} />);
     await userEvent.click(screen.getByTestId("group-selector"));
     await waitFor(() => {
       expect(screen.getByDisplayValue("Test Group")).toBeInTheDocument();
     });
   });
 
-  it("enables Trash button after a group is selected", async () => {
-    render(<PersonaAccessGroup initialSelectedGroup={null} />);
-    await userEvent.click(screen.getByTestId("group-selector"));
-    await waitFor(() => {
-      const buttons = screen.getAllByRole("button");
-      const trashBtn = buttons.find(
-        (b) => !b.hasAttribute("disabled") && b !== screen.getByTestId("group-selector")
-      );
-      expect(trashBtn).toBeDefined();
-    });
-  });
-
   it("clears group when Trash button is clicked", async () => {
-    render(<PersonaAccessGroup initialSelectedGroup={null} />);
-    // First select a group
+    render(<PersonaAccessGroup {...defaultProps} />);
     await userEvent.click(screen.getByTestId("group-selector"));
     await waitFor(() => screen.getByDisplayValue("Test Group"));
 
-    // Click the first non-disabled button that isn't the selector — the trash icon
-    const trashButtons = screen.getAllByRole("button").filter(
-      (b) => !b.hasAttribute("disabled") && b !== screen.getByTestId("group-selector")
-    );
+    const trashButtons = screen
+      .getAllByRole("button")
+      .filter(
+        (b) =>
+          !b.hasAttribute("disabled") &&
+          b !== screen.getByTestId("group-selector")
+      );
     await userEvent.click(trashButtons[0]);
     await waitFor(() => {
       expect(
-        screen.getByDisplayValue("Everyone can view this agent")
+        screen.getByDisplayValue("Only you can access this agent")
       ).toBeInTheDocument();
     });
+  });
+
+  // ── Publishing ────────────────────────────────────────────────────────────
+
+  it("shows the published summary and disables group controls when published", () => {
+    render(
+      <PersonaAccessGroup
+        {...defaultProps}
+        initialIsPublished
+        trustLevel="community"
+      />
+    );
+    expect(
+      screen.getByDisplayValue("Published — everyone can use this agent")
+    ).toBeInTheDocument();
+    // Publish switch is on; group selector and trash are deactivated.
+    expect(screen.getByRole("switch")).toBeChecked();
+    expect(screen.getByTestId("group-selector")).toBeDisabled();
+    expect(screen.getByText("Community")).toBeInTheDocument();
+  });
+
+  it("toggling the publish switch updates summary and re-enables the selector", async () => {
+    render(<PersonaAccessGroup {...defaultProps} />);
+    const publishSwitch = screen.getByRole("switch");
+    expect(publishSwitch).not.toBeChecked();
+
+    await userEvent.click(publishSwitch);
+    expect(
+      screen.getByDisplayValue("Published — everyone can use this agent")
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("group-selector")).toBeDisabled();
+
+    await userEvent.click(publishSwitch);
+    expect(
+      screen.getByDisplayValue("Only you can access this agent")
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("group-selector")).not.toBeDisabled();
+  });
+
+  it("publish switch has an accessible name", () => {
+    render(<PersonaAccessGroup {...defaultProps} />);
+    expect(
+      screen.getByRole("switch", { name: "Publish to the whole organization" })
+    ).toBeInTheDocument();
   });
 });

--- a/src/features/persona-page/persona-access-group/persona-access-group.tsx
+++ b/src/features/persona-page/persona-access-group/persona-access-group.tsx
@@ -1,19 +1,25 @@
 import { Label } from "@/features/ui/label";
 import { FC, useEffect, useState } from "react";
 import { PersonaAccessGroupSelector } from "./persona-access-group-selector";
-import { AccessGroup } from "../persona-services/models";
+import { AccessGroup, TrustLevel } from "../persona-services/models";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/features/ui/tooltip";
 import { Info, Trash } from "lucide-react";
 import { Button } from "@/features/ui/button";
+import { Switch } from "@/features/ui/switch";
 import { AccessGroupById } from "../persona-services/access-group-service";
 import { logoutOnSessionExpired } from "@/features/auth-page/logout-on-session-expired";
+import { TrustBadge } from "../persona-card/trust-badge";
 
 interface Props {
   initialSelectedGroup: string | null;
+  initialIsPublished: boolean;
+  /** Effective trust tier when the agent is already published, else null. */
+  trustLevel: TrustLevel | null;
 }
 
 export const PersonaAccessGroup: FC<Props> = (props) => {
   const [selectedGroup, setSelectedGroup] = useState<AccessGroup | null>();
+  const [isPublished, setIsPublished] = useState(props.initialIsPublished);
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
@@ -36,6 +42,14 @@ export const PersonaAccessGroup: FC<Props> = (props) => {
     fetchGroupDetails();
   }, [props.initialSelectedGroup]);
 
+  // Publishing supersedes group sharing: everyone has access anyway, so the
+  // group selection is deactivated while the agent is published.
+  const accessSummary = () => {
+    if (isPublished) return "Published — everyone can use this agent";
+    if (selectedGroup) return selectedGroup.name;
+    return "Only you can access this agent";
+  };
+
   return (
     <div className="grid gap-2">
       <div className="flex items-center space-x-2 justify-between">
@@ -55,7 +69,8 @@ export const PersonaAccessGroup: FC<Props> = (props) => {
             variant={"ghost"}
             type="button"
             size={"icon"}
-            disabled={!selectedGroup}
+            className="disabled:cursor-not-allowed"
+            disabled={!selectedGroup || isPublished}
             onClick={() => setSelectedGroup(null)}
           >
             <Trash size={15} className="text-red-600" />
@@ -63,6 +78,7 @@ export const PersonaAccessGroup: FC<Props> = (props) => {
           <PersonaAccessGroupSelector
             onSelectGroup={(e: any) => setSelectedGroup(e)}
             selectedAccessGroupId={selectedGroup?.id ?? ""}
+            disabled={isPublished}
           />
         </div>
       </div>
@@ -70,18 +86,13 @@ export const PersonaAccessGroup: FC<Props> = (props) => {
         <div className="border border-input bg-background rounded-md p-2 flex items-center w-full">
           {isLoading ? (
             <div className="animate-pulse w-full h-4 bg-muted rounded-md" />
-          ) : selectedGroup ? (
-            <input
-              value={selectedGroup.name}
-              readOnly
-              className="w-full bg-transparent"
-              disabled
-            />
           ) : (
             <input
-              value="Everyone can view this agent"
+              value={accessSummary()}
               readOnly
-              className="w-full bg-transparent text-muted-foreground"
+              className={`w-full bg-transparent ${
+                selectedGroup ? "" : "text-muted-foreground"
+              }`}
               disabled
             />
           )}
@@ -92,6 +103,23 @@ export const PersonaAccessGroup: FC<Props> = (props) => {
             type="hidden"
           />
         </div>
+      </div>
+      {/* Publishing is part of access: fresh publishes start as "community"
+          — see persona-service. */}
+      <div className="flex items-center gap-2 pt-1">
+        <Switch
+          id="isPublished"
+          name="isPublished"
+          checked={isPublished}
+          onCheckedChange={setIsPublished}
+        />
+        <Label
+          htmlFor="isPublished"
+          className="text-muted-foreground font-normal"
+        >
+          Publish to the whole organization
+        </Label>
+        {props.trustLevel && <TrustBadge level={props.trustLevel} />}
       </div>
     </div>
   );

--- a/src/features/persona-page/persona-card/persona-card-context-menu.tsx
+++ b/src/features/persona-page/persona-card/persona-card-context-menu.tsx
@@ -3,27 +3,47 @@
 import { DropdownMenuItemWithIcon } from "@/features/chat-page/chat-menu/chat-menu-item";
 import { RevalidateCache } from "@/features/common/navigation-helpers";
 import { LoadingIndicator } from "@/features/ui/loading";
-import { MoreVertical, Pencil, Trash } from "lucide-react";
+import {
+  BadgeCheck,
+  BadgeX,
+  MoreVertical,
+  Pencil,
+  Store,
+  Trash,
+} from "lucide-react";
 import { FC, useState } from "react";
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "../../ui/dropdown-menu";
-import { PersonaModel } from "../persona-services/models";
+import { effectiveTrustLevel, PersonaModel } from "../persona-services/models";
+import {
+  SetAgentTrustLevel,
+  UnpublishAgent,
+} from "../persona-services/agent-trust-service";
 import { DeletePersona } from "../persona-services/persona-service";
 import { personaStore } from "../persona-store";
 
 interface Props {
   persona: PersonaModel;
+  /** Owner/admin actions (edit, delete). */
+  showOwnerActions?: boolean;
+  /** Governance actions on published agents (verify/downgrade/unpublish). */
+  isVerifier?: boolean;
 }
 
-type DropdownAction = "edit" | "delete";
+type DropdownAction = "delete" | "verify" | "downgrade" | "unpublish";
 
 export const PersonaCardContextMenu: FC<Props> = (props) => {
-  const { isLoading, handleAction } = useDropdownAction({
-    persona: props.persona,
-  });
+  const { persona, showOwnerActions = true, isVerifier = false } = props;
+  const { isLoading, handleAction } = useDropdownAction({ persona });
+
+  const trustLevel = effectiveTrustLevel(persona);
+  const showVerifierActions = isVerifier && persona.isPublished;
+
+  if (!showOwnerActions && !showVerifierActions) return null;
 
   return (
     <>
@@ -36,18 +56,48 @@ export const PersonaCardContextMenu: FC<Props> = (props) => {
           )}
         </DropdownMenuTrigger>
         <DropdownMenuContent>
-          <DropdownMenuItemWithIcon
-            onClick={() => personaStore.updatePersona(props.persona)}
-          >
-            <Pencil size={18} />
-            <span>Edit</span>
-          </DropdownMenuItemWithIcon>
-          <DropdownMenuItemWithIcon
-            onClick={async () => await handleAction("delete")}
-          >
-            <Trash size={18} />
-            <span>Delete</span>
-          </DropdownMenuItemWithIcon>
+          {showOwnerActions && (
+            <>
+              <DropdownMenuItemWithIcon
+                onClick={() => personaStore.updatePersona(persona)}
+              >
+                <Pencil size={18} />
+                <span>Edit</span>
+              </DropdownMenuItemWithIcon>
+              <DropdownMenuItemWithIcon
+                onClick={async () => await handleAction("delete")}
+              >
+                <Trash size={18} />
+                <span>Delete</span>
+              </DropdownMenuItemWithIcon>
+            </>
+          )}
+          {showOwnerActions && showVerifierActions && <DropdownMenuSeparator />}
+          {showVerifierActions && (
+            <>
+              {trustLevel === "community" ? (
+                <DropdownMenuItemWithIcon
+                  onClick={async () => await handleAction("verify")}
+                >
+                  <BadgeCheck size={18} />
+                  <span>Mark as Verified</span>
+                </DropdownMenuItemWithIcon>
+              ) : (
+                <DropdownMenuItemWithIcon
+                  onClick={async () => await handleAction("downgrade")}
+                >
+                  <BadgeX size={18} />
+                  <span>Downgrade to Community</span>
+                </DropdownMenuItemWithIcon>
+              )}
+              <DropdownMenuItemWithIcon
+                onClick={async () => await handleAction("unpublish")}
+              >
+                <Store size={18} />
+                <span>Unpublish agent</span>
+              </DropdownMenuItemWithIcon>
+            </>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
     </>
@@ -58,6 +108,15 @@ const useDropdownAction = (props: { persona: PersonaModel }) => {
   const { persona } = props;
   const [isLoading, setIsLoading] = useState(false);
 
+  const revalidate = () => {
+    RevalidateCache({
+      page: "persona",
+    });
+    RevalidateCache({
+      page: "agent",
+    });
+  };
+
   const handleAction = async (action: DropdownAction) => {
     setIsLoading(true);
     switch (action) {
@@ -66,14 +125,26 @@ const useDropdownAction = (props: { persona: PersonaModel }) => {
           window.confirm(`Are you sure you want to delete ${persona.name}?`)
         ) {
           await DeletePersona(persona.id);
-          RevalidateCache({
-            page: "persona",
-          });
-          RevalidateCache({
-            page: "agent",
-          });
+          revalidate();
         }
-
+        break;
+      case "verify":
+        await SetAgentTrustLevel(persona.id, "verified");
+        revalidate();
+        break;
+      case "downgrade":
+        await SetAgentTrustLevel(persona.id, "community");
+        revalidate();
+        break;
+      case "unpublish":
+        if (
+          window.confirm(
+            `Unpublish ${persona.name} for the whole organization? Only the owner will still see it.`
+          )
+        ) {
+          await UnpublishAgent(persona.id);
+          revalidate();
+        }
         break;
     }
     setIsLoading(false);

--- a/src/features/persona-page/persona-card/persona-card.tsx
+++ b/src/features/persona-page/persona-card/persona-card.tsx
@@ -1,3 +1,7 @@
+import {
+  AgentStatsModel,
+  formatCount,
+} from "@/features/common/services/agent-stats-models";
 import { FC } from "react";
 import {
   Card,
@@ -6,8 +10,9 @@ import {
   CardHeader,
   CardTitle,
 } from "../../ui/card";
-import { PersonaModel } from "../persona-services/models";
+import { effectiveTrustLevel, PersonaModel } from "../persona-services/models";
 import { PersonaCardContextMenu } from "./persona-card-context-menu";
+import { TrustBadge } from "./trust-badge";
 import { ViewPersona } from "./persona-view";
 import { StartNewPersonaChat } from "./start-new-persona-chat";
 import { CopyAgentLinksMenu } from "./copy-agent-links-menu";
@@ -20,10 +25,19 @@ interface Props {
   showActionMenu: boolean;
   isFavorited?: boolean;
   onToggleFavorite?: (agentId: string) => void;
+  /** Current user may verify/downgrade/unpublish published agents. */
+  isVerifier?: boolean;
+  /** Global usage counters for this agent, when available. */
+  stats?: AgentStatsModel;
 }
 
 export const PersonaCard: FC<Props> = (props) => {
-  const { persona } = props;
+  const { persona, stats } = props;
+
+  const trustLevel = effectiveTrustLevel(persona);
+  const showVerifierActions = Boolean(
+    props.isVerifier && persona.isPublished
+  );
 
   return (
     <Card key={persona.id} data-persona-id={persona.id} className="flex flex-col">
@@ -39,14 +53,37 @@ export const PersonaCard: FC<Props> = (props) => {
             />
           )}
         </div>
-        {props.showActionMenu && (
+        {(props.showActionMenu || showVerifierActions) && (
           <div>
-            <PersonaCardContextMenu persona={persona} />
+            <PersonaCardContextMenu
+              persona={persona}
+              showOwnerActions={props.showActionMenu}
+              isVerifier={props.isVerifier}
+            />
           </div>
         )}
       </CardHeader>
-      <CardContent className="text-muted-foreground flex-1 line-clamp-3">
-        {persona.description}
+      {/* line-clamp on an inner element: clamping the padded CardContent
+          itself lets a clipped extra line bleed into its bottom padding.
+          The badge/stats band always renders (min-h) so descriptions align
+          across a card grid row. */}
+      <CardContent className="text-muted-foreground flex-1">
+        <div className="flex items-center gap-2 mb-2 min-h-6">
+          {trustLevel && <TrustBadge level={trustLevel} />}
+          {stats && (
+            <span
+              className={`text-xs whitespace-nowrap ${trustLevel ? "ml-auto" : ""}`}
+            >
+              {formatCount(stats.chatCount)}{" "}
+              {stats.chatCount === 1 ? "chat" : "chats"} ·{" "}
+              {formatCount(stats.messageCount)}{" "}
+              {stats.messageCount === 1 ? "msg" : "msgs"} ·{" "}
+              {formatCount(stats.totalInputTokens + stats.totalOutputTokens)}{" "}
+              tokens
+            </span>
+          )}
+        </div>
+        <p className="line-clamp-3">{persona.description}</p>
       </CardContent>
       <CardFooter className="gap-1 content-stretch f">
         {props.showContextMenu && <ViewPersona persona={persona} />}

--- a/src/features/persona-page/persona-card/persona-visibility-info.tsx
+++ b/src/features/persona-page/persona-card/persona-visibility-info.tsx
@@ -87,7 +87,7 @@ export const PersonaVisibilityInfo = (
       return "This agent is shared with one of your access groups.";
     }
 
-    return "This agent is public, so everyone in your organization can see it.";
+    return "This agent is published, so everyone in your organization can find and use it.";
   };
 
   return (

--- a/src/features/persona-page/persona-card/trust-badge.tsx
+++ b/src/features/persona-page/persona-card/trust-badge.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { FC } from "react";
+import { BadgeCheck, Users } from "lucide-react";
+import { Badge } from "../../ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../../ui/tooltip";
+import { TrustLevel } from "../persona-services/models";
+
+interface TrustBadgeProps {
+  level: TrustLevel;
+}
+
+const BADGE_CONTENT: Record<
+  TrustLevel,
+  { label: string; tooltip: string; icon: typeof BadgeCheck }
+> = {
+  verified: {
+    label: "Verified",
+    tooltip: "Reviewed and verified by the Bühler agent governance team.",
+    icon: BadgeCheck,
+  },
+  community: {
+    label: "Community",
+    tooltip:
+      "Published by a colleague and not yet reviewed — use your own judgment.",
+    icon: Users,
+  },
+};
+
+export const TrustBadge: FC<TrustBadgeProps> = ({ level }) => {
+  const { label, tooltip, icon: Icon } = BADGE_CONTENT[level];
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          {/* Neutral outline for Community so the brand color is reserved
+              for Verified — the actual trust signal. tabIndex makes the
+              tooltip keyboard-reachable. */}
+          <Badge
+            variant={level === "verified" ? "default" : "outline"}
+            className={`gap-1 shrink-0 cursor-default ${
+              level === "community" ? "text-muted-foreground" : ""
+            }`}
+            tabIndex={0}
+          >
+            <Icon className="h-3 w-3" />
+            {label}
+          </Badge>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" className="max-w-[240px]">
+          {tooltip}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};

--- a/src/features/persona-page/persona-page.tsx
+++ b/src/features/persona-page/persona-page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { AgentStatsModel } from "@/features/common/services/agent-stats-models";
 import { FC } from "react";
 import { ScrollArea } from "../ui/scroll-area";
 import { AddNewPersona } from "./add-new-persona";
@@ -13,6 +14,8 @@ interface ChatPersonaProps {
   extensions: ExtensionModel[];
   initialFavoriteIds: string[];
   currentUserId: string;
+  agentStats?: Record<string, AgentStatsModel>;
+  isVerifier?: boolean;
 }
 
 export const ChatPersonaPage: FC<ChatPersonaProps> = (props) => {
@@ -25,6 +28,8 @@ export const ChatPersonaPage: FC<ChatPersonaProps> = (props) => {
             personas={props.personas}
             initialFavoriteIds={props.initialFavoriteIds}
             currentUserId={props.currentUserId}
+            agentStats={props.agentStats}
+            isVerifier={props.isVerifier}
             showContextMenu
           />
         </div>

--- a/src/features/persona-page/persona-services/agent-trust-service.test.ts
+++ b/src/features/persona-page/persona-services/agent-trust-service.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ── Graph client mock ────────────────────────────────────────────────────────
+const mockGraphPost = vi.fn();
+vi.mock("@/features/common/services/microsoft-graph-client", () => ({
+  getGraphClient: vi.fn(() => ({
+    api: vi.fn(() => ({ post: mockGraphPost })),
+  })),
+}));
+
+// ── auth helpers mock ────────────────────────────────────────────────────────
+const mockGetCurrentUser = vi.fn();
+vi.mock("@/features/auth-page/helpers", () => ({
+  getCurrentUser: (...args: any[]) => mockGetCurrentUser(...args),
+}));
+
+// ── Cosmos mock ──────────────────────────────────────────────────────────────
+const mockQueryFetchAll = vi.fn();
+const mockPatch = vi.fn();
+let lastItemArgs: [string, string] | null = null;
+
+vi.mock("@/features/common/services/cosmos", () => ({
+  HistoryContainer: vi.fn(() => ({
+    items: {
+      query: vi.fn(() => ({ fetchAll: mockQueryFetchAll })),
+    },
+    item: (id: string, pk: string) => {
+      lastItemArgs = [id, pk];
+      return { patch: mockPatch };
+    },
+  })),
+}));
+
+vi.mock("@/features/common/navigation-helpers", () => ({
+  RevalidateCache: vi.fn(),
+}));
+
+vi.mock("@/features/common/services/logger", () => ({
+  logError: vi.fn(),
+}));
+
+import {
+  IsAgentVerifier,
+  SetAgentTrustLevel,
+  UnpublishAgent,
+} from "./agent-trust-service";
+
+const GROUP_ID = "11111111-2222-3333-4444-555555555555";
+
+const graphUser = () => ({
+  name: "U",
+  email: "u@buhlergroup.com",
+  isAdmin: false,
+  isLocalDevUser: false,
+  token: "graph-token",
+});
+
+const seedPersonaDoc = (overrides: Record<string, any> = {}) => ({
+  id: "p1",
+  userId: "owner-hash",
+  name: "Agent",
+  description: "d",
+  personaMessage: "m",
+  isPublished: true,
+  type: "PERSONA",
+  createdAt: new Date(),
+  extensionIds: [],
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  lastItemArgs = null;
+  vi.stubEnv("AGENT_VERIFIER_GROUP_ID", GROUP_ID);
+  mockGetCurrentUser.mockResolvedValue(graphUser());
+  mockGraphPost.mockResolvedValue({ value: [GROUP_ID] });
+  mockQueryFetchAll.mockResolvedValue({ resources: [seedPersonaDoc()] });
+  mockPatch.mockImplementation(async (ops: any[]) => ({
+    resource: { ...seedPersonaDoc(), _patched: ops },
+  }));
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("persona.unit.agent-trust — IsAgentVerifier", () => {
+  it("trust.001: false when AGENT_VERIFIER_GROUP_ID is unset (fail closed)", async () => {
+    vi.stubEnv("AGENT_VERIFIER_GROUP_ID", "");
+    await expect(IsAgentVerifier()).resolves.toBe(false);
+    expect(mockGraphPost).not.toHaveBeenCalled();
+  });
+
+  it("trust.002: true for local-dev users without hitting Graph", async () => {
+    mockGetCurrentUser.mockResolvedValue({
+      ...graphUser(),
+      isLocalDevUser: true,
+    });
+    await expect(IsAgentVerifier()).resolves.toBe(true);
+    expect(mockGraphPost).not.toHaveBeenCalled();
+  });
+
+  it("trust.003: true when checkMemberGroups returns the group", async () => {
+    await expect(IsAgentVerifier()).resolves.toBe(true);
+    expect(mockGraphPost).toHaveBeenCalledWith({ groupIds: [GROUP_ID] });
+  });
+
+  it("trust.004: false when the group is not in the response", async () => {
+    mockGraphPost.mockResolvedValue({ value: [] });
+    await expect(IsAgentVerifier()).resolves.toBe(false);
+  });
+
+  it("trust.005: false on Graph errors (fail closed)", async () => {
+    mockGraphPost.mockRejectedValue(new Error("graph down"));
+    await expect(IsAgentVerifier()).resolves.toBe(false);
+  });
+
+  it("trust.006: false when the user has no token", async () => {
+    mockGetCurrentUser.mockResolvedValue({ ...graphUser(), token: "" });
+    await expect(IsAgentVerifier()).resolves.toBe(false);
+    expect(mockGraphPost).not.toHaveBeenCalled();
+  });
+});
+
+describe("persona.unit.agent-trust — SetAgentTrustLevel", () => {
+  it("trust.007: UNAUTHORIZED for non-members; nothing written", async () => {
+    mockGraphPost.mockResolvedValue({ value: [] });
+    const result = await SetAgentTrustLevel("p1", "verified");
+    expect(result.status).toBe("UNAUTHORIZED");
+    expect(mockPatch).not.toHaveBeenCalled();
+  });
+
+  it("trust.008: patches /trustLevel on the owner's partition", async () => {
+    const result = await SetAgentTrustLevel("p1", "verified");
+    expect(result.status).toBe("OK");
+    expect(lastItemArgs).toEqual(["p1", "owner-hash"]);
+    expect(mockPatch).toHaveBeenCalledWith([
+      { op: "set", path: "/trustLevel", value: "verified" },
+    ]);
+  });
+
+  it("trust.009: NOT_FOUND when the agent does not exist", async () => {
+    mockQueryFetchAll.mockResolvedValue({ resources: [] });
+    const result = await SetAgentTrustLevel("missing", "verified");
+    expect(result.status).toBe("NOT_FOUND");
+    expect(mockPatch).not.toHaveBeenCalled();
+  });
+});
+
+describe("persona.unit.agent-trust — UnpublishAgent", () => {
+  it("trust.010: unpublish stamps community (blocks legacy auto-verify)", async () => {
+    const result = await UnpublishAgent("p1");
+    expect(result.status).toBe("OK");
+    expect(mockPatch).toHaveBeenCalledWith([
+      { op: "set", path: "/isPublished", value: false },
+      { op: "set", path: "/trustLevel", value: "community" },
+    ]);
+  });
+
+  it("trust.011: UNAUTHORIZED for non-members", async () => {
+    mockGraphPost.mockResolvedValue({ value: [] });
+    const result = await UnpublishAgent("p1");
+    expect(result.status).toBe("UNAUTHORIZED");
+    expect(mockPatch).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/persona-page/persona-services/agent-trust-service.ts
+++ b/src/features/persona-page/persona-services/agent-trust-service.ts
@@ -1,0 +1,146 @@
+"use server";
+import "server-only";
+
+import { getCurrentUser } from "@/features/auth-page/helpers";
+import { ServerActionResponse } from "@/features/common/server-action-response";
+import { HistoryContainer } from "@/features/common/services/cosmos";
+import { logError } from "@/features/common/services/logger";
+import { getGraphClient } from "@/features/common/services/microsoft-graph-client";
+import { RevalidateCache } from "@/features/common/navigation-helpers";
+import { SqlQuerySpec } from "@azure/cosmos";
+import { PERSONA_ATTRIBUTE, PersonaModel, TrustLevel } from "./models";
+
+/**
+ * Whether the current user may classify marketplace agents (verify/downgrade/
+ * unpublish). Membership in the Entra ID group configured via
+ * AGENT_VERIFIER_GROUP_ID — checked with Graph `/me/checkMemberGroups`, which
+ * (unlike the Unified-filtered /me/memberOf used for access groups) also
+ * covers security groups and transitive membership. `Group.Read.All` in the
+ * requested scopes already covers this call.
+ *
+ * Fails closed: unset group id, missing token, or Graph errors → false.
+ */
+export const IsAgentVerifier = async (): Promise<boolean> => {
+  try {
+    const groupId = process.env.AGENT_VERIFIER_GROUP_ID?.trim();
+    if (!groupId) return false;
+
+    const user = await getCurrentUser();
+    // Dev short-circuit, consistent with access-group-service's placeholder.
+    if (user.isLocalDevUser) return true;
+    if (!user.token) return false;
+
+    const result = await getGraphClient(user.token)
+      .api("/me/checkMemberGroups")
+      .post({ groupIds: [groupId] });
+
+    return Array.isArray(result?.value) && result.value.includes(groupId);
+  } catch (error) {
+    logError("agent-trust: checkMemberGroups failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+};
+
+/**
+ * Raw persona lookup for verifier actions. Deliberately does NOT reuse
+ * FindPersonaByID: its accessGroup gate would block verifiers who aren't
+ * members of an agent's share group.
+ */
+const findPersonaRaw = async (id: string): Promise<PersonaModel | null> => {
+  const querySpec: SqlQuerySpec = {
+    query: "SELECT * FROM root r WHERE r.type=@type AND r.id=@id",
+    parameters: [
+      { name: "@type", value: PERSONA_ATTRIBUTE },
+      { name: "@id", value: id },
+    ],
+  };
+  const { resources } = await HistoryContainer()
+    .items.query<PersonaModel>(querySpec)
+    .fetchAll();
+  return resources[0] ?? null;
+};
+
+const revalidateAgentPages = () => {
+  RevalidateCache({ page: "chat" });
+  RevalidateCache({ page: "agent" });
+  RevalidateCache({ page: "persona" });
+};
+
+const UNAUTHORIZED_RESPONSE: ServerActionResponse<PersonaModel> = {
+  status: "UNAUTHORIZED",
+  errors: [{ message: "Only agent verifiers may change trust classification" }],
+};
+
+/**
+ * Sets the trust classification of a published agent. Verifier-group only —
+ * membership is re-checked server-side on every call.
+ */
+export const SetAgentTrustLevel = async (
+  personaId: string,
+  trustLevel: TrustLevel
+): Promise<ServerActionResponse<PersonaModel>> => {
+  try {
+    if (!(await IsAgentVerifier())) return UNAUTHORIZED_RESPONSE;
+
+    const persona = await findPersonaRaw(personaId);
+    if (!persona) {
+      return {
+        status: "NOT_FOUND",
+        errors: [{ message: `Agent not found with id: ${personaId}` }],
+      };
+    }
+
+    const { resource } = await HistoryContainer()
+      .item(personaId, persona.userId)
+      .patch<PersonaModel>([
+        { op: "set", path: "/trustLevel", value: trustLevel },
+      ]);
+
+    revalidateAgentPages();
+    return { status: "OK", response: resource! };
+  } catch (error) {
+    return {
+      status: "ERROR",
+      errors: [{ message: `Error setting trust level: ${error}` }],
+    };
+  }
+};
+
+/**
+ * Removes an agent from the marketplace (governance action; owners unpublish
+ * via their edit sheet). Also stamps trustLevel="community" so a legacy
+ * agent unpublished by a verifier cannot resurface as auto-Verified when the
+ * owner re-publishes it.
+ */
+export const UnpublishAgent = async (
+  personaId: string
+): Promise<ServerActionResponse<PersonaModel>> => {
+  try {
+    if (!(await IsAgentVerifier())) return UNAUTHORIZED_RESPONSE;
+
+    const persona = await findPersonaRaw(personaId);
+    if (!persona) {
+      return {
+        status: "NOT_FOUND",
+        errors: [{ message: `Agent not found with id: ${personaId}` }],
+      };
+    }
+
+    const { resource } = await HistoryContainer()
+      .item(personaId, persona.userId)
+      .patch<PersonaModel>([
+        { op: "set", path: "/isPublished", value: false },
+        { op: "set", path: "/trustLevel", value: "community" },
+      ]);
+
+    revalidateAgentPages();
+    return { status: "OK", response: resource! };
+  } catch (error) {
+    return {
+      status: "ERROR",
+      errors: [{ message: `Error unpublishing agent: ${error}` }],
+    };
+  }
+};

--- a/src/features/persona-page/persona-services/models.ts
+++ b/src/features/persona-page/persona-services/models.ts
@@ -61,6 +61,25 @@ export const AccessGroupSchema = z.object({
 export const PERSONA_ATTRIBUTE = "PERSONA";
 export type PersonaModel = z.infer<typeof PersonaModelSchema>;
 
+// Trust classification of published agents. "verified" = reviewed by the
+// agent-governance Entra ID group; "community" = published by a user,
+// unreviewed. Only group members may change it (see agent-trust-service).
+export const TRUST_LEVELS = ["verified", "community"] as const;
+export type TrustLevel = (typeof TRUST_LEVELS)[number];
+
+/**
+ * Effective trust tier of an agent, or null when not published.
+ * Legacy rule: agents published before trust tiers existed went through the
+ * admin-only publish gate, so a published agent without a stored trustLevel
+ * counts as "verified". UpsertPersona materializes the field on save, so the
+ * legacy branch shrinks over time.
+ */
+export const effectiveTrustLevel = (persona: {
+  isPublished: boolean;
+  trustLevel?: TrustLevel;
+}): TrustLevel | null =>
+  !persona.isPublished ? null : persona.trustLevel ?? "verified";
+
 export const DefaultToolsSchema = z.object({
   webSearch: z.boolean().optional(),
   imageGeneration: z.boolean().optional(),
@@ -94,7 +113,10 @@ export const PersonaModelSchema = z.object({
   extensionIds: z.array(z.string()),
   isPublished: z.boolean(),
   type: z.literal(PERSONA_ATTRIBUTE),
-  createdAt: z.date(),
+  createdAt: z.coerce.date(), // coerce: Cosmos round-trips dates as ISO strings
+  updatedAt: z.coerce.date().optional(), // last modification (createdAt is no longer overwritten on update)
+  publishedAt: z.coerce.date().optional(), // first false→true publish transition
+  trustLevel: z.enum(TRUST_LEVELS).optional(), // see effectiveTrustLevel for the legacy default
   personaDocumentIds: z.array(z.string()).optional(),
   codeInterpreterDocumentIds: z.array(z.string()).optional(), // SharePoint documents for Code Interpreter
   accessGroup: AccessGroupSchema.optional(),

--- a/src/features/persona-page/persona-services/persona-service.test.ts
+++ b/src/features/persona-page/persona-services/persona-service.test.ts
@@ -4,7 +4,6 @@ import { defaultSession, adminSession, setSession } from "@/__tests__/helpers/se
 
 const hashEmail = (e: string) => createHash("sha256").update(e).digest("hex");
 const USER_HASH = hashEmail(defaultSession!.user.email);
-const ADMIN_HASH = hashEmail(adminSession!.user.email);
 
 // ── Cosmos mock (direct module mock, bypasses singleton) ─────────────────────
 let historyItems: any[] = [];
@@ -162,26 +161,30 @@ beforeEach(() => {
 // ── tests ─────────────────────────────────────────────────────────────────────
 
 describe("persona-service.ts", () => {
-  // 001 – CreatePersona forces isPublished=false for non-admin
-  it("001 CreatePersona forces isPublished=false for non-admin", async () => {
+  // 001 – CreatePersona lets any user publish; fresh publish starts as community
+  it("001 CreatePersona lets any user publish as community", async () => {
     await setSession(defaultSession);
     const result = await CreatePersona({ ...validPersonaInput(), isPublished: true }, []);
     expect(result.status).toBe("OK");
     if (result.status === "OK") {
-      expect(result.response.isPublished).toBe(false);
+      expect(result.response.isPublished).toBe(true);
+      expect(result.response.trustLevel).toBe("community");
+      expect(result.response.publishedAt).toBeInstanceOf(Date);
       expect(result.response.userId).toBe(USER_HASH);
       expect(result.response.id).toBeTruthy();
       expect(result.response.type).toBe("PERSONA");
     }
   });
 
-  // 002 – CreatePersona allows admin to publish
-  it("002 CreatePersona allows admin to publish", async () => {
-    await setSession(adminSession);
-    const result = await CreatePersona({ ...validPersonaInput(), isPublished: true }, []);
+  // 002 – CreatePersona without publish stores no trust metadata
+  it("002 CreatePersona unpublished has no trustLevel/publishedAt", async () => {
+    await setSession(defaultSession);
+    const result = await CreatePersona(validPersonaInput(), []);
     expect(result.status).toBe("OK");
     if (result.status === "OK") {
-      expect(result.response.isPublished).toBe(true);
+      expect(result.response.isPublished).toBe(false);
+      expect(result.response.trustLevel).toBeUndefined();
+      expect(result.response.publishedAt).toBeUndefined();
     }
   });
 
@@ -314,15 +317,79 @@ describe("persona-service.ts", () => {
     expect(historyItems.find((i: any) => i.id === "p-del")).toBeUndefined();
   });
 
-  // 012 – UpsertPersona preserves existing isPublished for non-admin
-  it("012 UpsertPersona preserves existing isPublished for non-admin", async () => {
+  // 012 – UpsertPersona lets the owner publish/unpublish
+  it("012a UpsertPersona fresh publish stamps community + publishedAt", async () => {
     await setSession(defaultSession);
-    const p = seedPersona({ id: "p-upsert", isPublished: true });
+    const p = seedPersona({ id: "p-upsert", isPublished: false });
+
+    const result = await UpsertPersona({ ...p, isPublished: true }, []);
+    expect(result.status).toBe("OK");
+    if (result.status === "OK") {
+      expect(result.response.isPublished).toBe(true);
+      expect(result.response.trustLevel).toBe("community");
+      expect(result.response.publishedAt).toBeInstanceOf(Date);
+    }
+  });
+
+  it("012b UpsertPersona owner can unpublish; trustLevel is retained", async () => {
+    await setSession(defaultSession);
+    const p = seedPersona({
+      id: "p-unpub",
+      isPublished: true,
+      trustLevel: "community",
+      publishedAt: new Date("2026-01-01"),
+    });
 
     const result = await UpsertPersona({ ...p, isPublished: false }, []);
     expect(result.status).toBe("OK");
     if (result.status === "OK") {
-      expect(result.response.isPublished).toBe(true);
+      expect(result.response.isPublished).toBe(false);
+      // Stored classification survives an unpublish/republish cycle.
+      expect(result.response.trustLevel).toBe("community");
+      expect(result.response.publishedAt).toEqual(new Date("2026-01-01"));
+    }
+  });
+
+  it("012c UpsertPersona materializes legacy published agents as verified", async () => {
+    await setSession(defaultSession);
+    // Legacy: published via the old admin-only gate, before trustLevel existed.
+    const p = seedPersona({ id: "p-legacy", isPublished: true });
+
+    const result = await UpsertPersona({ ...p, isPublished: true }, []);
+    expect(result.status).toBe("OK");
+    if (result.status === "OK") {
+      expect(result.response.trustLevel).toBe("verified");
+    }
+  });
+
+  it("012d UpsertPersona keeps a stored verified level on edit", async () => {
+    await setSession(defaultSession);
+    const p = seedPersona({
+      id: "p-verified",
+      isPublished: true,
+      trustLevel: "verified",
+    });
+
+    const result = await UpsertPersona({ ...p, name: "Renamed" }, []);
+    expect(result.status).toBe("OK");
+    if (result.status === "OK") {
+      expect(result.response.trustLevel).toBe("verified");
+    }
+  });
+
+  it("012e UpsertPersona preserves createdAt and stamps updatedAt", async () => {
+    await setSession(defaultSession);
+    const created = new Date("2025-03-03T12:00:00Z");
+    const p = seedPersona({ id: "p-times", createdAt: created.toISOString() });
+
+    const result = await UpsertPersona({ ...p, createdAt: created }, []);
+    expect(result.status).toBe("OK");
+    if (result.status === "OK") {
+      expect(result.response.createdAt).toEqual(created);
+      expect(result.response.updatedAt).toBeInstanceOf(Date);
+      expect(result.response.updatedAt!.getTime()).toBeGreaterThan(
+        created.getTime()
+      );
     }
   });
 

--- a/src/features/persona-page/persona-services/persona-service.ts
+++ b/src/features/persona-page/persona-services/persona-service.ts
@@ -36,6 +36,10 @@ import {
 import { UploadFileForCodeInterpreter } from "@/features/chat-page/chat-services/code-interpreter-service";
 import { AccessGroupById, UserAccessGroups } from "./access-group-service";
 import { RevalidateCache } from "@/features/common/navigation-helpers";
+import {
+  DeleteAgentStats,
+  RecordAgentChatStarted,
+} from "@/features/common/services/agent-stats-service";
 import { logInfo, logError } from "@/features/common/services/logger";
 
 interface PersonaInput {
@@ -122,8 +126,6 @@ export const CreatePersona = async (
   sharePointFiles: DocumentMetadata[]
 ): Promise<ServerActionResponse<PersonaModel>> => {
   try {
-    const user = await getCurrentUser();
-
     // TODO: check if the user is part of the access group
 
     const personaDocumentIds = await AddOrUpdatePersonaDocuments(
@@ -142,9 +144,14 @@ export const CreatePersona = async (
       name: props.name,
       description: props.description,
       personaMessage: props.personaMessage,
-      isPublished: user.isAdmin ? props.isPublished : false,
+      // Any user may publish their agent to the marketplace; fresh publishes
+      // start as "community" until the governance group verifies them.
+      isPublished: props.isPublished,
+      trustLevel: props.isPublished ? "community" : undefined,
+      publishedAt: props.isPublished ? new Date() : undefined,
       userId: await userHashedId(),
       createdAt: new Date(),
+      updatedAt: new Date(),
       extensionIds: props.extensionIds,
       type: "PERSONA",
       personaDocumentIds: personaDocumentIds.response,
@@ -228,6 +235,9 @@ export const DeletePersona = async (
         .item(personaId, personaResponse.response.userId)
         .delete();
 
+      // Best-effort cleanup of the agent's usage counters.
+      await DeleteAgentStats(personaId);
+
       return {
         status: "OK",
         response: deletedPersona,
@@ -258,7 +268,6 @@ export const UpsertPersona = async (
 
     if (personaResponse.status === "OK") {
       const { response: persona } = personaResponse;
-      const user = await getCurrentUser();
 
       const personaDocumentIdsResponse = await AddOrUpdatePersonaDocuments(
         sharePointFiles,
@@ -271,15 +280,39 @@ export const UpsertPersona = async (
         personaDocumentIds = personaDocumentIdsResponse.response;
       }
 
+      const wasPublished = persona.isPublished;
+      const willPublish = personaInput.isPublished;
+
+      // Trust stamping: a published agent without a stored trustLevel is a
+      // legacy admin-published one (effectively "verified") — materialize
+      // that on save. A fresh publish (or republish) starts as "community";
+      // only the governance group can raise it (agent-trust-service).
+      const trustLevel =
+        willPublish && !persona.trustLevel
+          ? wasPublished
+            ? ("verified" as const)
+            : ("community" as const)
+          : persona.trustLevel;
+
       const modelToUpdate: PersonaModel = {
         ...persona,
         name: personaInput.name,
         description: personaInput.description,
         personaMessage: personaInput.personaMessage,
-        isPublished: user.isAdmin
-          ? personaInput.isPublished
-          : persona.isPublished,
-        createdAt: new Date(),
+        // Owners publish their own agents to the marketplace themselves
+        // (EnsurePersonaOperation already restricts edits to owner/admin).
+        isPublished: willPublish,
+        trustLevel,
+        publishedAt:
+          willPublish && !wasPublished
+            ? new Date()
+            : persona.publishedAt
+              ? new Date(persona.publishedAt)
+              : undefined,
+        // Preserve the original creation time (Cosmos round-trips it as an
+        // ISO string, hence the coercion); track modifications in updatedAt.
+        createdAt: new Date(persona.createdAt),
+        updatedAt: new Date(),
         extensionIds: personaInput.extensionIds,
         accessGroup: personaInput.accessGroup,
         personaDocumentIds: personaDocumentIds,
@@ -517,6 +550,7 @@ export const CreatePersonaChat = async (
       type: CHAT_THREAD_ATTRIBUTE,
       personaMessage: persona.personaMessage,
       personaMessageTitle: persona.name,
+      personaId: persona.id,
       extension: persona.extensionIds || [],
       personaDocumentIds: persona.personaDocumentIds || [],
       attachedFiles: attachedFiles.length > 0 ? attachedFiles : undefined,
@@ -524,6 +558,11 @@ export const CreatePersonaChat = async (
       subAgentIds: persona.subAgentIds || [],
       defaultTools: persona.defaultTools,
     });
+
+    if (response.status === "OK") {
+      // Fire-and-forget: stats must never block or fail chat creation.
+      RecordAgentChatStarted(persona.id).catch(() => {});
+    }
 
     return response;
   }

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "azure-open-ai-accelerator",
-  "version": "1.2.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "azure-open-ai-accelerator",
-      "version": "1.2.0",
+      "version": "2.4.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.0",
         "@ai-sdk/azure": "^3.0.65",

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-open-ai-accelerator",
-  "version": "1.2.0",
+  "version": "2.4.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/playwright.config.ts
+++ b/src/playwright.config.ts
@@ -69,10 +69,12 @@ export default defineConfig({
       // at process start; without them chat-api-response.ts returns
       // "Missing deployment configuration" before the fake OpenAI is invoked.
       // The fake is wired via webpack alias regardless of the value here.
+      AZURE_OPENAI_API_GPT56_SOL_DEPLOYMENT_NAME: "gpt-test",
+      AZURE_OPENAI_API_GPT56_TERRA_DEPLOYMENT_NAME: "gpt-test",
+      AZURE_OPENAI_API_GPT56_LUNA_DEPLOYMENT_NAME: "gpt-test",
       AZURE_OPENAI_API_GPT55_DEPLOYMENT_NAME: "gpt-test",
       AZURE_OPENAI_API_GPT54_DEPLOYMENT_NAME: "gpt-test",
       AZURE_OPENAI_API_GPT54_MINI_DEPLOYMENT_NAME: "gpt-test",
-      AZURE_OPENAI_API_GPT53_CHAT_DEPLOYMENT_NAME: "gpt-test",
       AZURE_OPENAI_API_VERSION: "2024-10-21",
       AZURE_SEARCH_API_KEY: "test-search-key",
       AZURE_SEARCH_NAME: "test-search",

--- a/src/public/changelog.md
+++ b/src/public/changelog.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Agent Publishing & Statistics
+- **Added:** You can now publish your agents to the whole organization — find the switch in the agent's "Access to Agent" section.
+- **Added:** Trust levels for published agents: **Verified** (reviewed by the agent governance team) and **Community** (published by a colleague), shown as badges on agent cards. Governance-team members can verify, downgrade, or unpublish agents.
+- **Added:** Usage statistics per agent — chats, messages, and tokens — shown on agent cards.
+- **Added:** Sort agents by most used (default), recently updated, newest, or name, plus a trust-level filter on the Agents page.
+- **Changed:** The home page now shows only your favorite agents; discover and manage all agents on the Agents page ("Browse all agents").
+- **Fixed:** Editing an agent no longer bumps it to the top of the "Newest" sort order.
+
 ### Logging Improvements
 - **Enhanced:** Replaced console.log statements with centralized logging utility across the entire codebase
 - **Added:** Structured logging with context support for better debugging

--- a/src/public/changelog.md
+++ b/src/public/changelog.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## [Unreleased]
+## [v2.4.0] – 2026-07-10
 
 ### Agent Publishing & Statistics
 - **Added:** You can now publish your agents to the whole organization — find the switch in the agent's "Access to Agent" section.
@@ -9,6 +9,12 @@
 - **Added:** Sort agents by most used (default), recently updated, newest, or name, plus a trust-level filter on the Agents page.
 - **Changed:** The home page now shows only your favorite agents; discover and manage all agents on the Agents page ("Browse all agents").
 - **Fixed:** Editing an agent no longer bumps it to the top of the "Newest" sort order.
+
+### Model Updates
+- **Added:** GPT-5.6 Sol, Terra, and Luna are now available, deployed to both dev and prod.
+- **Changed:** GPT-5.6 Sol is now the default model.
+- **Changed:** GPT-5.6 Luna replaces GPT-5.4 Mini as the automatic cost-cap downgrade target.
+- **Removed:** GPT-5.3 Chat is no longer available.
 
 ### Logging Improvements
 - **Enhanced:** Replaced console.log statements with centralized logging utility across the entire codebase


### PR DESCRIPTION
## Summary

Two commits, releasing **v2.4.0**:

### 1. `feat(agents)` — organization-wide publishing, trust levels, usage statistics
- **Publish to the whole organization**: any user can publish their agent via a switch in the agent's *Access to Agent* section (no longer admin-only). Publishing supersedes Entra-group sharing — the group selector is deactivated while published.
- **Trust levels**: published agents carry a **Verified** / **Community** badge. Legacy admin-published agents count as Verified (lazily materialized on save). Verify / downgrade / unpublish actions are restricted to members of the Entra ID group configured in `AGENT_VERIFIER_GROUP_ID` (Graph `checkMemberGroups` — supports security groups; fail-closed when unset; membership re-checked server-side on every action).
- **Per-agent usage statistics** (chats, interactions, tokens) as **atomic Cosmos counters**: one `AGENT_STATS` doc per agent under a sentinel partition, updated via Patch-API `incr` from `CreatePersonaChat` and `persistThread` (chat threads now carry `personaId`). No time series; display reads are a single-partition query, never container scans.
- **Home/agents UX**: home shows favorites only + "Browse all agents"; the Agents page gains sorting (**most used** default / recently updated / newest / name) and a trust filter; stats + badges on cards.
- **Fix**: `UpsertPersona` no longer overwrites `createdAt` on every edit (the root cause of "last edited agent always on top"); adds `updatedAt`.

### 2. `feat(models)` — GPT-5.6 family + rolling budget window + release
- GPT-5.6 **Sol / Terra / Luna** added; Sol is the new default; Luna replaces GPT-5.4 Mini as cost-cap downgrade target; GPT-5.3 Chat removed.
- `GetWeeklyUsage` now computes an exact rolling 7-calendar-day window; usage menu wording updated.
- Changelog dated + version bumped to 2.4.0.

## Configuration
- New env var: `AGENT_VERIFIER_GROUP_ID` (Entra group object ID; empty = trust actions disabled). Needs to be set in dev/prod app settings for the governance team to classify agents.

## Test plan
- [x] Unit tests: new suites for agent-stats (Patch ops, 404-create/409-repatch races), agent-trust (group gating fail-closed, unpublish stamps community), publish/trust stamping incl. legacy lazy-verify; e2e Cosmos fake taught `incr`. All green.
- [x] `next build` clean.
- [x] Live-verified on dev (Chrome DevTools): publish flow end-to-end, trust filter/badges, verifier fail-closed for non-members, stats counters verified against the Cosmos doc (incl. concurrent chats aggregating correctly), most-used sorting, delete cascade removes the stats doc.
- Note: `npm run lint` (`next lint` removed in Next 16) and 28 tests in 7 Azure-SDK/DI test files are broken on `main` already — unrelated to this PR.
