### PR TITLE
fix(models): correct GPT-5.6 Luna pricing to announced $1/$6 rates

### DIFF
--- a/src/features/chat-page/chat-services/models.ts
+++ b/src/features/chat-page/chat-services/models.ts
@@ -99,9 +99,10 @@ export interface ModelConfig {
 
 export const MODEL_CONFIGS: Record<ChatModel, ModelConfig> = {
   // ── GPT-5.6 family (2026-07-09) ─────────────────────────────────────────
-  // Pricing mirrors the equivalent GPT-5.5-era tier as a placeholder — Azure's
-  // model catalog doesn't expose $/token pricing (cost field is null for every
-  // model, including gpt-5.5 below). Confirm against the real Bühler contract.
+  // Pricing per the OpenAI GPT-5.6 announcement: Sol $5/$30, Terra $2.50/$15,
+  // Luna $1/$6 per 1M tokens; cache reads keep the 90% cached-input discount.
+  // NOTE: gpt-5.6+ bills cache WRITES at 1.25× the uncached input rate — not
+  // yet modelled here, so totalCostUsd slightly underestimates on cache writes.
   "gpt-5.6-sol": {
     id: "gpt-5.6-sol",
     name: "GPT-5.6 Sol",
@@ -141,7 +142,7 @@ export const MODEL_CONFIGS: Record<ChatModel, ModelConfig> = {
     supportsResponsesAPI: true,
     deploymentName: process.env.AZURE_OPENAI_API_GPT56_LUNA_DEPLOYMENT_NAME,
     defaultReasoningEffort: "medium",
-    pricing: { inputPerMillion: 0.75, outputPerMillion: 4.50, cachedInputPerMillion: 0.075 },
+    pricing: { inputPerMillion: 1.00, outputPerMillion: 6.00, cachedInputPerMillion: 0.10 },
     contextWindow: 400000,
     hardCapEligible: true,
     capabilities: ["vision", "webSearch", "code"],

--- a/src/features/common/services/__tests__/downgrade-config.test.ts
+++ b/src/features/common/services/__tests__/downgrade-config.test.ts
@@ -63,7 +63,7 @@ describe("getBudgetConfig", () => {
 
 describe("getDowngradeTargets — hardCapSet", () => {
   it("includes flagged+deployed models, sorted cheapest-first by output price", () => {
-    // output prices: DeepSeek 1.20 < Kimi 2.50 < luna 4.50
+    // output prices: DeepSeek 1.20 < Kimi 2.50 < luna 6.00
     const { hardCapSet } = getDowngradeTargets();
     expect(hardCapSet).toEqual(["DeepSeek-V4-Pro", "Kimi-K2.6", "gpt-5.6-luna"]);
   });


### PR DESCRIPTION
Luna shipped in v2.4.0 with placeholder pricing mirroring gpt-5.4-mini ($0.75/$4.50/$0.075). The official GPT-5.6 announcement prices Luna at **$1 input / $6 output / $0.10 cached** per 1M tokens.

Since Luna is the active budget-cap downgrade target, prod cost tracking currently underestimates capped users' spend by ~25%, which also skews the daily/weekly budget-window math itself.

Also updates the GPT-5.6 pricing comment (Sol $5/$30 and Terra $2.50/$15 confirmed correct) and notes the not-yet-modelled 1.25× cache-write billing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)